### PR TITLE
fix: sync custom fluid values for linked dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@arts/fluid-design-system",
   "author": "Artem Semkin",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "license": "GPL-3.0-or-later",
   "description": "",

--- a/src/js/views/BaseControlView.js
+++ b/src/js/views/BaseControlView.js
@@ -933,19 +933,15 @@ export const BaseControlView = {
         [setting]: clampValue
       }
 
-      this.setValue(newValue)
-
-      // Update related input for Elementor's internal tracking
-      // @ts-expect-error - Type assertion for ui access
-      const relatedInputEl = this.ui.controls.filter(`[data-setting="${setting}"]`)
-      relatedInputEl.val(clampValue)
-
-      // Handle linked dimensions/gaps - sync all inputs to same value
+      // Handle linked dimensions/gaps - sync all values and inputs
       if (this.isLinkedDimensions()) {
         // @ts-expect-error - Type assertion for ui access
         for (const selectEl of this.ui.selectControls || []) {
           const otherSetting = selectEl.getAttribute('data-setting')
           if (otherSetting && otherSetting !== setting) {
+            // Add linked dimension value to the model update
+            newValue[otherSetting] = clampValue
+
             const otherContainer = this.getInlineContainer(otherSetting)
             if (otherContainer) {
               const minInput = otherContainer.querySelector('[data-fluid-role="min"]')
@@ -962,10 +958,22 @@ export const BaseControlView = {
 
               // Update button state for this container
               this.updateSaveButtonState(otherContainer)
+
+              // Update related input for Elementor's internal tracking
+              // @ts-expect-error - Type assertion for ui access
+              const linkedInputEl = this.ui.controls.filter(`[data-setting="${otherSetting}"]`)
+              linkedInputEl.val(clampValue)
             }
           }
         }
       }
+
+      this.setValue(newValue)
+
+      // Update related input for Elementor's internal tracking
+      // @ts-expect-error - Type assertion for ui access
+      const relatedInputEl = this.ui.controls.filter(`[data-setting="${setting}"]`)
+      relatedInputEl.val(clampValue)
 
       this.updateDimensions()
     }

--- a/src/wordpress-plugin/fluid-design-system-for-elementor.php
+++ b/src/wordpress-plugin/fluid-design-system-for-elementor.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Fluid Design System for Elementor
  * Description: Provides comprehensive fluid spacing and typography system for Elementor for smoother and consistent responsive design
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: Artem Semkin
  * Author URI: https://artemsemkin.com
  * License: GPLv3

--- a/src/wordpress-plugin/readme.txt
+++ b/src/wordpress-plugin/readme.txt
@@ -4,7 +4,7 @@ Tags: typography, spacing, responsive, fluid, elementor
 Requires at least: 6.0
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 2.0.0
+Stable tag: 2.0.1
 license: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0
 Text Domain: fluid-design-system-for-elementor
@@ -193,6 +193,9 @@ The plugin uses the CSS `clamp()` function, which is supported by all modern bro
 5. Applying fluid unit for "gaps" control
 
 == Changelog ==
+
+= 2.0.1 =
+* fixed: custom fluid values now sync correctly when dimensions are linked
 
 = 2.0.0 =
 * added: set fluid values directly in controls ("20px ~ 100px") without visiting Site Settings


### PR DESCRIPTION
Custom fluid values (e.g., "50px ~ 10px") now correctly update all linked dimension sides.

**Before:** Only the active dimension updated; linked sides showed stale CSS values.
**After:** All linked dimensions sync to the same clamp formula.