### PR TITLE
refactor: clean up PHP comments and add type annotations

### DIFF
--- a/src/php/Elementor/Tabs/FluidTypographySpacing.php
+++ b/src/php/Elementor/Tabs/FluidTypographySpacing.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Fluid Typography and Spacing tab for Elementor.
+ * Fluid Typography and Spacing tab for Elementor Site Settings.
  *
  * @package Arts\FluidDesignSystem
  * @since 1.0.0
@@ -9,7 +9,7 @@
 namespace Arts\FluidDesignSystem\Elementor\Tabs;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit;
 }
 
 use Elementor\Core\Kits\Controls\Repeater as Global_Style_Repeater;
@@ -22,80 +22,46 @@ use Arts\FluidDesignSystem\Managers\GroupsData;
 use Arts\Utilities\Utilities;
 
 /**
- * FluidTypographySpacing Class
- *
- * Implements a tab in Elementor for controlling fluid typography
- * and spacing presets with responsive scaling.
+ * Elementor Site Settings tab for fluid typography and spacing presets.
  *
  * @since 1.0.0
  */
 class FluidTypographySpacing extends BaseTab {
-	/**
-	 * Tab identifier.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @var string
-	 */
+	/** @var string */
 	const TAB_ID = 'arts-fluid-design-system-tab-fluid-typography-spacing';
 
-	/**
-	 * Get the title of the tab.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string The tab title.
-	 */
+	/** @inheritDoc */
 	public function get_title(): string {
 		return esc_html__( 'Fluid Typography & Spacing', 'fluid-design-system-for-elementor' );
 	}
 
-	/**
-	 * Get the group this tab belongs to.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string The tab group.
-	 */
+	/** @inheritDoc */
 	public function get_group(): string {
 		return 'global';
 	}
 
-	/**
-	 * Get the icon for this tab.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return string The tab icon.
-	 */
+	/** @inheritDoc */
 	public function get_icon(): string {
 		return 'eicon-spacer';
 	}
 
 	/**
-	 * Factory method to create a fluid preset repeater control.
+	 * Creates a fluid preset repeater control with consistent configuration.
 	 *
-	 * Creates a standardized fluid preset repeater control with consistent
-	 * configuration across all fluid preset types (built-in and custom).
+	 * The 'is_fluid_preset_repeater' flag enables JS-side detection for custom UI behavior.
 	 *
 	 * @since 1.0.0
-	 * @access public
 	 *
-	 * @param string   $control_id The control ID.
-	 * @param array<string, mixed>    $args       Optional additional control arguments.
-	 * @param Repeater|null $repeater   Optional custom repeater instance.
-	 * @return array<string, mixed>                  The control configuration array.
+	 * @param string                $control_id Control ID.
+	 * @param array<string, mixed>  $args       Optional control arguments to merge.
+	 * @param Repeater|null         $repeater   Optional custom repeater instance.
+	 * @return array<string, mixed> The control configuration.
 	 */
 	public function create_fluid_preset_control( $control_id, $args = array(), $repeater = null ): array {
-		// Get the repeater control (use provided or create new)
 		if ( null === $repeater ) {
 			$repeater = $this->get_repeater_control();
 		}
 
-		// Base configuration for all fluid preset controls
 		$base_config = array(
 			'type'                     => Global_Style_Repeater::CONTROL_TYPE,
 			'fields'                   => $repeater->get_controls(),
@@ -108,36 +74,24 @@ class FluidTypographySpacing extends BaseTab {
 			'render_type'              => 'template',
 		);
 
-		// Merge with custom arguments (allows overriding defaults)
 		$config = array_merge( $base_config, $args );
-
-		// Add the control to this instance
 		$this->add_control( $control_id, $config );
 
 		return $config;
 	}
 
 	/**
-	 * Factory method to create a fluid preset section with optional description.
-	 *
-	 * Creates a complete fluid preset section including:
-	 * - Section start with proper labeling
-	 * - Optional description/info control
-	 * - Fluid preset repeater control
-	 * - Section end
+	 * Creates a complete fluid preset section with optional info alert.
 	 *
 	 * @since 1.0.0
-	 * @access public
 	 *
-	 * @param string $section_id   The section ID.
-	 * @param string $control_id   The control ID for the repeater.
-	 * @param string $label        The section label.
-	 * @param string $description  Optional description text.
-	 * @param array<string, mixed>  $args         Optional additional control arguments.
-	 * @return void
+	 * @param string               $section_id  Section ID.
+	 * @param string               $control_id  Repeater control ID.
+	 * @param string               $label       Section label.
+	 * @param string               $description Optional info text shown as alert.
+	 * @param array<string, mixed> $args        Optional control arguments.
 	 */
 	public function create_fluid_preset_section( $section_id, $control_id, $label, $description = '', $args = array() ): void {
-		// Start the section
 		$this->start_controls_section(
 			$section_id,
 			array(
@@ -146,11 +100,9 @@ class FluidTypographySpacing extends BaseTab {
 			)
 		);
 
-		// Add description if provided
 		if ( ! empty( $description ) ) {
-			$info_control_id = $control_id . '_info';
 			$this->add_control(
-				$info_control_id,
+				$control_id . '_info',
 				array(
 					'type'            => Controls_Manager::RAW_HTML,
 					'raw'             => esc_html( $description ),
@@ -159,27 +111,19 @@ class FluidTypographySpacing extends BaseTab {
 			);
 		}
 
-		// Create the fluid preset control
 		$this->create_fluid_preset_control( $control_id, $args );
-
-		// End the section
 		$this->end_controls_section();
 	}
 
 	/**
-	 * Convenience method to create a custom group section using the factory.
-	 *
-	 * This is a specialized version of create_fluid_preset_section() that
-	 * automatically generates IDs and uses consistent naming patterns for custom groups.
+	 * Creates a custom group section with auto-generated IDs from ControlRegistry.
 	 *
 	 * @since 1.0.0
-	 * @access public
 	 *
-	 * @param string $group_id     The custom group ID.
-	 * @param string $name         The group display name.
-	 * @param string $description  Optional description text.
-	 * @param array<string, mixed>  $args         Optional additional control arguments.
-	 * @return void
+	 * @param string               $group_id    Custom group ID.
+	 * @param string               $name        Display name.
+	 * @param string               $description Optional info text.
+	 * @param array<string, mixed> $args        Optional control arguments.
 	 */
 	public function create_custom_group_section( $group_id, $name, $description = '', $args = array() ): void {
 		$section_id = ControlRegistry::get_custom_group_section_id( $group_id );
@@ -188,32 +132,14 @@ class FluidTypographySpacing extends BaseTab {
 		$this->create_fluid_preset_section( $section_id, $control_id, $name, $description, $args );
 	}
 
-	/**
-	 * Register tab controls.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return void
-	 */
+	/** @inheritDoc */
 	protected function register_tab_controls(): void {
-		// Always register breakpoints first
 		$this->register_section_fluid_breakpoints();
-
-		// Register main groups (built-in + custom) in correct order
 		$this->register_main_group_sections();
 	}
 
-	/**
-	 * Register sections for main groups (built-in + custom) in correct order.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
+	/** Registers built-in and custom group sections in user-defined order. */
 	private function register_main_group_sections(): void {
-		// Get the main groups in the correct order
 		$main_groups = $this->get_main_groups_from_manager();
 
 		foreach ( $main_groups as $group ) {
@@ -230,25 +156,16 @@ class FluidTypographySpacing extends BaseTab {
 	}
 
 	/**
-	 * Get main groups from the groups data manager.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<int, array<string, mixed>> Array of main groups.
+	 * @return array<int, array<string, mixed>>
 	 */
 	private function get_main_groups_from_manager(): array {
 		return GroupsData::get_main_groups();
 	}
 
 	/**
-	 * Register a section for a built-in group.
+	 * Routes built-in group IDs to their registration methods.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group Group data.
-	 * @return void
+	 * @param array<string, mixed> $group Group data with 'id' key.
 	 */
 	private function register_builtin_group_section( array $group ): void {
 		if ( ! isset( $group['id'] ) ) {
@@ -269,36 +186,21 @@ class FluidTypographySpacing extends BaseTab {
 	}
 
 	/**
-	 * Register a section for a custom group.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group_data Group data from groups data manager.
-	 * @return void
+	 * @param array<string, mixed> $group_data Group data from GroupsData.
 	 */
 	private function register_custom_group_section( array $group_data ): void {
-		// Extract group information from the groups data manager format
 		$group_id    = Utilities::get_string_value( $group_data['id'] ?? '' );
 		$name        = Utilities::get_string_value( $group_data['name'] ?? '' );
 		$description = Utilities::get_string_value( $group_data['description'] ?? '' );
 
 		if ( empty( $group_id ) || empty( $name ) ) {
-			return; // Skip invalid groups
+			return;
 		}
 
-		// Use convenience method for custom groups
 		$this->create_custom_group_section( $group_id, $name, $description );
 	}
 
-	/**
-	 * Register fluid breakpoints section.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
+	/** Global breakpoints used for clamp() calculations when presets don't override. */
 	private function register_section_fluid_breakpoints(): void {
 		$this->start_controls_section(
 			'section_fluid_breakpoints',
@@ -308,7 +210,6 @@ class FluidTypographySpacing extends BaseTab {
 			)
 		);
 
-		// Screen width settings
 		$this->add_control(
 			'min_screen_width',
 			array(
@@ -345,12 +246,10 @@ class FluidTypographySpacing extends BaseTab {
 	}
 
 	/**
-	 * Get repeater control for fluid presets.
+	 * Builds the repeater control structure for fluid presets.
 	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return Repeater The repeater control.
+	 * The 'title' selector generates the clamp() CSS variable using min/max values.
+	 * Override controls allow per-preset breakpoint customization.
 	 */
 	private function get_repeater_control(): Repeater {
 		$repeater = new Repeater();
@@ -464,9 +363,8 @@ class FluidTypographySpacing extends BaseTab {
 			)
 		);
 
-		// Note: Using the same CSS variable name with different conditions
-		// Elementor's CSS processing will use the last defined value
-		// This allows us to override the default clamp formula with custom screen widths
+		// Selector intentionally redefines the same CSS variable - Elementor uses last value,
+		// allowing custom breakpoints to override the default clamp formula when enabled
 		$repeater->add_control(
 			'override_screen_width_enabled',
 			array(
@@ -527,67 +425,45 @@ class FluidTypographySpacing extends BaseTab {
 		$repeater->end_popover();
 
 		/**
-		 * Filter the repeater control.
+		 * Allows adding custom fields to the preset repeater.
 		 *
 		 * @since 1.0.0
-		 *
-		 * @param Repeater $repeater The repeater control.
-		 * @param self $tab The current tab instance.
+		 * @param Repeater $repeater The repeater instance.
+		 * @param self     $tab      The current tab instance.
+		 * @return Repeater
 		 */
-		return apply_filters( 'arts/fluid_design_system/controls/fluid_preset_repeater', $repeater, $this );
+		$filtered = apply_filters( 'arts/fluid_design_system/controls/fluid_preset_repeater', $repeater, $this );
+
+		return $filtered instanceof Repeater ? $filtered : $repeater;
 	}
 
-	/**
-	 * Register fluid spacing section.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
 	private function register_section_fluid_spacing(): void {
-		// Get metadata for consistent labeling
 		$metadata = ControlRegistry::get_builtin_group_metadata();
 
 		if ( ! isset( $metadata['spacing'] ) || ! is_array( $metadata['spacing'] ) ) {
 			return;
 		}
 
-		$spacing_metadata = $metadata['spacing'];
-
-		// Use factory method to create the complete section
 		$this->create_fluid_preset_section(
 			'section_fluid_spacing_presets',
 			'fluid_spacing_presets',
-			Utilities::get_string_value( $spacing_metadata['name'] ?? '' ),
-			Utilities::get_string_value( $spacing_metadata['description'] ?? '' )
+			Utilities::get_string_value( $metadata['spacing']['name'] ?? '' ),
+			Utilities::get_string_value( $metadata['spacing']['description'] ?? '' )
 		);
 	}
 
-	/**
-	 * Register fluid typography section.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
 	private function register_section_fluid_typography(): void {
-		// Get metadata for consistent labeling
 		$metadata = ControlRegistry::get_builtin_group_metadata();
 
 		if ( ! isset( $metadata['typography'] ) || ! is_array( $metadata['typography'] ) ) {
 			return;
 		}
 
-		$typography_metadata = $metadata['typography'];
-
-		// Use factory method to create the complete section
 		$this->create_fluid_preset_section(
 			'section_fluid_typography_presets',
 			'fluid_typography_presets',
-			Utilities::get_string_value( $typography_metadata['name'] ?? '' ),
-			Utilities::get_string_value( $typography_metadata['description'] ?? '' )
+			Utilities::get_string_value( $metadata['typography']['name'] ?? '' ),
+			Utilities::get_string_value( $metadata['typography']['description'] ?? '' )
 		);
 	}
 }

--- a/src/php/Managers/Admin/Frontend.php
+++ b/src/php/Managers/Admin/Frontend.php
@@ -1,31 +1,29 @@
 <?php
+/**
+ * Admin page assets (CSS/JS) enqueuing.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 
+/**
+ * Enqueues modular CSS/JS for admin groups management page.
+ */
 class Frontend extends BaseManager {
 
-	/**
-	 * Enqueue admin assets.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param string $hook_suffix The current admin page hook suffix.
-	 * @return void
-	 */
+	/** Hooked to admin_enqueue_scripts. */
 	public function enqueue_assets( string $hook_suffix ): void {
-		// Only enqueue on our admin pages
 		if ( strpos( $hook_suffix, 'fluid-design-system' ) === false ) {
 			return;
 		}
 
-		// Enqueue jQuery UI Sortable for drag & drop functionality
 		wp_enqueue_script( 'jquery-ui-sortable' );
 
 		// Enqueue Elementor icons for the hero button
@@ -232,14 +230,7 @@ class Frontend extends BaseManager {
 		);
 	}
 
-	/**
-	 * Get control registry data for JavaScript.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, array<string, string>> Control registry mapping data.
-	 */
+	/** @return array<string, array<string, string>> */
 	private function get_control_registry_data(): array {
 		$registry_data = array();
 

--- a/src/php/Managers/Admin/Page.php
+++ b/src/php/Managers/Admin/Page.php
@@ -1,25 +1,25 @@
 <?php
+/**
+ * Admin menu registration and page container rendering.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 use Arts\Utilities\Utilities;
 
+/**
+ * Registers submenu under Elementor and renders tab-based admin page.
+ */
 class Page extends BaseManager {
-	/**
-	 * Add admin menu page.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return void
-	 */
+	/** Hooked to admin_menu. */
 	public function add_admin_menu(): void {
-		// Only add menu if Elementor is active
 		if ( ! Utilities::is_elementor_plugin_active() ) {
 			return;
 		}
@@ -35,14 +35,7 @@ class Page extends BaseManager {
 		);
 	}
 
-	/**
-	 * Render the admin page.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return void
-	 */
+	/** Page container with tab navigation and content. */
 	public function render_admin_page(): void {
 		// Check user capabilities
 		if ( ! current_user_can( 'manage_options' ) ) {

--- a/src/php/Managers/Admin/Tabs/Groups/AJAX.php
+++ b/src/php/Managers/Admin/Tabs/Groups/AJAX.php
@@ -1,9 +1,14 @@
 <?php
+/**
+ * AJAX handlers for admin group operations.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin\Tabs\Groups;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
@@ -11,16 +16,12 @@ use Arts\FluidDesignSystem\Managers\Data;
 use Arts\FluidDesignSystem\Managers\GroupsData;
 use Arts\Utilities\Utilities;
 
+/**
+ * Handles async operations for groups admin: title/description updates, reordering, bulk saves.
+ */
 class AJAX extends BaseManager {
-	/**
-	 * Handle AJAX requests for admin operations.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @return void
-	 */
-	public function handle_ajax_requests() {
+	/** Hooked to wp_ajax_fluid_design_system_admin_action. */
+	public function handle_ajax_requests(): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null ) {
 			wp_send_json_error(
@@ -86,14 +87,7 @@ class AJAX extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle AJAX title update.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, mixed> Operation result
-	 */
+	/** @return array<string, mixed> */
 	private function handle_ajax_update_title() {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
@@ -159,14 +153,7 @@ class AJAX extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle AJAX description update.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, mixed> Operation result
-	 */
+	/** @return array<string, mixed> */
 	private function handle_ajax_update_description() {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
@@ -223,14 +210,7 @@ class AJAX extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle AJAX groups reordering.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, mixed> Operation result
-	 */
+	/** @return array<string, mixed> */
 	private function handle_ajax_reorder_groups() {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null ) {
@@ -270,14 +250,7 @@ class AJAX extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle AJAX save all changes request.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, mixed> Array with success status and optional message.
-	 */
+	/** @return array<string, mixed> */
 	private function handle_ajax_save_all_changes() {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->admin_tabs_groups_handlers === null || $this->managers->admin_tabs_groups_view === null ) {
@@ -331,12 +304,11 @@ class AJAX extends BaseManager {
 	}
 
 	/**
-	 * Handle AJAX preset snapshot save - PROPER ELEMENTOR API APPROACH.
+	 * Saves preset organization via Kit post meta directly.
 	 *
-	 * @since 1.0.0
-	 * @access private
+	 * Uses Page Settings Manager API to preserve metadata during cross-group moves.
 	 *
-	 * @return array<string, mixed> Operation result
+	 * @return array<string, mixed>
 	 */
 	private function handle_ajax_save_presets_snapshot() {
 		// Nonce verification is handled in handle_ajax_requests()
@@ -457,17 +429,8 @@ class AJAX extends BaseManager {
 		);
 	}
 
-	/**
-	 * Check if a group name is already taken (custom, built-in, or filter-based).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param string $name Group name to check.
-	 * @param string $exclude_id Optional. Group ID to exclude from check.
-	 * @return bool True if name is taken, false otherwise.
-	 */
-	private function is_group_name_taken( $name, $exclude_id = null ) {
+	/** Checks all group types (custom, built-in, filter-based) for duplicate names. */
+	private function is_group_name_taken( string $name, ?string $exclude_id = null ): bool {
 		$sanitized_name = sanitize_text_field( $name );
 
 		// Check custom groups

--- a/src/php/Managers/Admin/Tabs/Groups/Handlers.php
+++ b/src/php/Managers/Admin/Tabs/Groups/Handlers.php
@@ -1,9 +1,14 @@
 <?php
+/**
+ * Form POST handlers for admin group CRUD operations.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin\Tabs\Groups;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
@@ -11,15 +16,17 @@ use Arts\FluidDesignSystem\Managers\Data;
 use Arts\FluidDesignSystem\Managers\GroupsData;
 use Arts\Utilities\Utilities;
 
+/**
+ * Handles synchronous form submissions: batch saves, create/delete actions.
+ */
 class Handlers extends BaseManager {
 	/**
-	 * Handle save all changes action (unified save for order, titles, descriptions, etc.)
+	 * Unified save processing new group creation, ordering, title/description updates, deletions.
 	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
+	 * Temporary IDs (temp_*) are mapped to real IDs after group creation to preserve
+	 * the user's intended order when new groups are added before saving.
 	 */
-	public function handle_save_all_changes() {
+	public function handle_save_all_changes(): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
 			return;
@@ -363,14 +370,8 @@ class Handlers extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle group actions (create, delete).
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return void
-	 */
-	public function handle_group_actions() {
+	/** Called from Page::render_admin_page() to process POST actions before rendering. */
+	public function handle_group_actions(): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
 			return;
@@ -413,15 +414,7 @@ class Handlers extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle create group action.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function handle_create_group() {
+	private function handle_create_group(): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
 			return;
@@ -451,15 +444,7 @@ class Handlers extends BaseManager {
 		}
 	}
 
-	/**
-	 * Handle delete group action.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function handle_delete_group() {
+	private function handle_delete_group(): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null || $this->managers->data === null ) {
 			return;
@@ -480,17 +465,8 @@ class Handlers extends BaseManager {
 		}
 	}
 
-	/**
-	 * Check if a group name is already taken (custom, built-in, or filter-based).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param string $name Group name to check.
-	 * @param string $exclude_id Optional. Group ID to exclude from check.
-	 * @return bool True if name is taken, false otherwise.
-	 */
-	private function is_group_name_taken( $name, $exclude_id = null ) {
+	/** Checks all group types (custom, built-in, filter-based) for duplicate names. */
+	private function is_group_name_taken( string $name, ?string $exclude_id = null ): bool {
 		$sanitized_name = sanitize_text_field( $name );
 
 		// Check custom groups

--- a/src/php/Managers/Admin/Tabs/Groups/View.php
+++ b/src/php/Managers/Admin/Tabs/Groups/View.php
@@ -1,25 +1,26 @@
 <?php
+/**
+ * Admin groups table rendering.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin\Tabs\Groups;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 use Arts\FluidDesignSystem\Managers\GroupsData;
 use Arts\Utilities\Utilities;
 
+/**
+ * Renders sortable groups table with inline editing and accordion presets.
+ */
 class View extends BaseManager {
-	/**
-	 * Render the Groups tab content.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array<string, mixed> $tab_data Tab data.
-	 * @return void
-	 */
-	public function render( $tab_data ) {
+	/** @param array<string, mixed> $tab_data */
+	public function render( $tab_data ): void {
 		// Check managers availability
 		if ( $this->managers === null || $this->managers->notices === null ) {
 			return;
@@ -168,42 +169,22 @@ class View extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Get rendered HTML for main groups table body.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string HTML for table body.
-	 */
-	public function get_main_groups_table_body_html() {
+	public function get_main_groups_table_body_html(): string {
 		ob_start();
 		$this->render_main_groups_table_body();
 		$output = ob_get_clean();
 		return is_string( $output ) ? $output : '';
 	}
 
-	/**
-	 * Get rendered HTML for developer groups table body.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string HTML for table body.
-	 */
-	public function get_developer_groups_table_body_html() {
+	public function get_developer_groups_table_body_html(): string {
 		ob_start();
 		$this->render_developer_groups_table_body();
 		$output = ob_get_clean();
 		return is_string( $output ) ? $output : '';
 	}
 
-	/**
-	 * Get complete main groups table HTML for AJAX responses.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string Complete HTML table.
-	 */
-	public function get_main_groups_table_html() {
+	/** Returns full table HTML for AJAX table refresh. */
+	public function get_main_groups_table_html(): string {
 		ob_start();
 		?>
 		<table class="wp-list-table widefat fixed" id="fluid-groups-sortable">
@@ -217,14 +198,8 @@ class View extends BaseManager {
 		return is_string( $output ) ? $output : '';
 	}
 
-	/**
-	 * Get complete developer groups table HTML for AJAX responses.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return string Complete HTML table.
-	 */
-	public function get_developer_groups_table_html() {
+	/** Returns full table HTML for AJAX table refresh. */
+	public function get_developer_groups_table_html(): string {
 		ob_start();
 		?>
 		<table class="wp-list-table widefat fixed" id="fluid-developer-groups-table-list">
@@ -238,15 +213,7 @@ class View extends BaseManager {
 		return is_string( $output ) ? $output : '';
 	}
 
-	/**
-	 * Render the main groups table (built-in + custom, sortable).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_main_groups_table() {
+	private function render_main_groups_table(): void {
 		?>
 		<form method="post" id="fluid-groups-form">
 			<?php wp_nonce_field( 'fluid_groups_action', 'fluid_groups_nonce' ); ?>
@@ -275,15 +242,7 @@ class View extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Render the developer groups table (filter-based, read-only).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_developer_groups_table() {
+	private function render_developer_groups_table(): void {
 		?>
 		<table class="wp-list-table widefat fixed" id="fluid-developer-groups-table-list">
 			<?php $this->render_table_header(); ?>
@@ -294,15 +253,7 @@ class View extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Render table header (shared between main and developer tables).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_table_header() {
+	private function render_table_header(): void {
 		?>
 		<thead>
 			<tr>
@@ -329,15 +280,7 @@ class View extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Render main groups table body content.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_main_groups_table_body() {
+	private function render_main_groups_table_body(): void {
 		$groups = GroupsData::get_main_groups();
 
 		if ( ! empty( $groups ) ) {
@@ -358,15 +301,7 @@ class View extends BaseManager {
 		$this->render_inline_add_row();
 	}
 
-	/**
-	 * Render developer groups table body content.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_developer_groups_table_body() {
+	private function render_developer_groups_table_body(): void {
 		$groups = GroupsData::get_filter_groups();
 
 		if ( ! empty( $groups ) ) {
@@ -385,16 +320,10 @@ class View extends BaseManager {
 	}
 
 	/**
-	 * Render a single group row for developer table (filter-based, read-only).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group Group data.
-	 * @param int                  $display_order Display order number.
-	 * @return void
+	 * @param array<string, mixed> $group
+	 * @param int                  $display_order
 	 */
-	private function render_developer_group_row( $group, $display_order = 1 ) {
+	private function render_developer_group_row( $group, $display_order = 1 ): void {
 		$group_name_raw    = isset( $group['name'] ) ? $group['name'] : ( isset( $group['title'] ) ? $group['title'] : esc_html__( 'Untitled Group', 'fluid-design-system-for-elementor' ) );
 		$group_name        = is_string( $group_name_raw ) ? esc_html( $group_name_raw ) : esc_html__( 'Untitled Group', 'fluid-design-system-for-elementor' );
 		$group_description = isset( $group['description'] ) && is_string( $group['description'] ) ? esc_html( $group['description'] ) : '';
@@ -444,17 +373,8 @@ class View extends BaseManager {
 	}
 
 
-	/**
-	 * Render preset list for accordion content.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group Group data.
-	 * @param bool                 $is_developer_group Whether this is for a developer group (read-only).
-	 * @return void
-	 */
-	private function render_group_presets( $group, $is_developer_group = false ) {
+	/** @param array<string, mixed> $group */
+	private function render_group_presets( $group, bool $is_developer_group = false ): void {
 		$presets = isset( $group['value'] ) && is_array( $group['value'] ) ? $group['value'] : array();
 
 		// Add wrapper div for smooth animations
@@ -491,16 +411,10 @@ class View extends BaseManager {
 	}
 
 	/**
-	 * Render individual preset item - ENSURE PRESET IDs ARE ALWAYS SET.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $preset Preset data.
-	 * @param array<string, mixed> $group Group data.
-	 * @return void
+	 * @param array<string, mixed> $preset
+	 * @param array<string, mixed> $group
 	 */
-	private function render_preset_item( $preset, $group ) {
+	private function render_preset_item( $preset, $group ): void {
 		// Generate a fallback ID if missing to prevent empty data-preset-id
 		$preset_id = isset( $preset['_id'] ) && is_string( $preset['_id'] ) && ! empty( $preset['_id'] )
 		? esc_attr( $preset['_id'] )
@@ -517,16 +431,10 @@ class View extends BaseManager {
 	}
 
 	/**
-	 * Render a single group row for main table (built-in + custom, all sortable).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group Group data.
-	 * @param int                  $display_order Display order number.
-	 * @return void
+	 * @param array<string, mixed> $group
+	 * @param int                  $display_order
 	 */
-	private function render_main_group_row( $group, $display_order = 1 ) {
+	private function render_main_group_row( $group, $display_order = 1 ): void {
 		$group_type        = isset( $group['type'] ) && is_string( $group['type'] ) ? $group['type'] : 'unknown';
 		$group_name_raw    = isset( $group['name'] ) ? $group['name'] : ( isset( $group['title'] ) ? $group['title'] : esc_html__( 'Untitled Group', 'fluid-design-system-for-elementor' ) );
 		$group_name        = is_string( $group_name_raw ) ? esc_html( $group_name_raw ) : esc_html__( 'Untitled Group', 'fluid-design-system-for-elementor' );
@@ -612,16 +520,8 @@ class View extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Render actions for custom groups (delete button).
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param array<string, mixed> $group Group data.
-	 * @return string HTML for group actions.
-	 */
-	private function render_custom_group_actions( $group ) {
+	/** @param array<string, mixed> $group */
+	private function render_custom_group_actions( $group ): string {
 		if ( ! isset( $group['id'] ) || ! is_string( $group['id'] ) ) {
 			return '';
 		}
@@ -635,15 +535,7 @@ class View extends BaseManager {
 		);
 	}
 
-	/**
-	 * Render inline add group row.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return void
-	 */
-	private function render_inline_add_row() {
+	private function render_inline_add_row(): void {
 		?>
 		<tr class="inline-add-row" id="inline-add-row">
 			<td class="column-order">

--- a/src/php/Managers/Admin/Tabs/Tabs.php
+++ b/src/php/Managers/Admin/Tabs/Tabs.php
@@ -1,23 +1,22 @@
 <?php
+/**
+ * Admin tab navigation and content routing.
+ *
+ * @package Arts\FluidDesignSystem
+ */
 
 namespace Arts\FluidDesignSystem\Managers\Admin\Tabs;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 
+/**
+ * Tab-based admin interface router.
+ */
 class Tabs extends BaseManager {
-	/**
-	 * Render navigation tabs.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param string $current_tab Current active tab.
-	 * @return void
-	 */
 	public function render_tabs( string $current_tab ): void {
 		$tabs = $this->get_tabs();
 
@@ -35,15 +34,6 @@ class Tabs extends BaseManager {
 		}
 	}
 
-	/**
-	 * Render tab content.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param string $current_tab Current active tab.
-	 * @return void
-	 */
 	public function render_tab_content( string $current_tab ): void {
 		if ( $this->managers === null ) {
 			return;
@@ -71,14 +61,7 @@ class Tabs extends BaseManager {
 		<?php
 	}
 
-	/**
-	 * Get available tabs.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @return array<string, array<string, string>> Array of tabs data.
-	 */
+	/** @return array<string, array<string, string>> */
 	public function get_tabs(): array {
 		return array(
 			'groups' => array(

--- a/src/php/Managers/Compatibility.php
+++ b/src/php/Managers/Compatibility.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Compatibility manager for Arts Fluid Design System.
+ * Editor script/style enqueuing and localization.
  *
  * @package Arts\FluidDesignSystem
  * @since 1.0.0
@@ -9,38 +9,21 @@
 namespace Arts\FluidDesignSystem\Managers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 
 /**
- * Compatibility Class
- *
- * Manages compatibility with Elementor editor by handling script
- * and style enqueuing, as well as providing localized strings.
+ * Elementor editor assets and localization.
  *
  * @since 1.0.0
  */
 class Compatibility extends BaseManager {
-	/**
-	 * Script and style handle.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @var string
-	 */
+	/** @var string */
 	private $handle = 'arts-fluid-design-system-editor';
 
-	/**
-	 * Enqueue the editor scripts.
-	 *
-	 * Registers and enqueues the necessary JavaScript files for the editor.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
+	/** Hooked to elementor/editor/after_enqueue_scripts. */
 	public function elementor_enqueue_editor_scripts(): void {
 		/** @var string|false $version */
 		$version = defined( 'ARTS_FLUID_DS_PLUGIN_VERSION' ) && is_string( constant( 'ARTS_FLUID_DS_PLUGIN_VERSION' ) )
@@ -55,7 +38,6 @@ class Compatibility extends BaseManager {
 			true
 		);
 
-		// Localize script with translation strings
 		wp_localize_script(
 			$this->handle,
 			'ArtsFluidDSStrings',
@@ -63,15 +45,7 @@ class Compatibility extends BaseManager {
 		);
 	}
 
-	/**
-	 * Enqueue the editor styles.
-	 *
-	 * Registers and enqueues the necessary CSS files for the editor.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @return void
-	 */
+	/** Hooked to elementor/editor/after_enqueue_styles. */
 	public function elementor_enqueue_editor_styles(): void {
 		/** @var string|false $version */
 		$version = defined( 'ARTS_FLUID_DS_PLUGIN_VERSION' ) && is_string( constant( 'ARTS_FLUID_DS_PLUGIN_VERSION' ) )
@@ -87,14 +61,9 @@ class Compatibility extends BaseManager {
 	}
 
 	/**
-	 * Get all translatable strings for localization.
+	 * Keys must match constants in JS: interfaces/IArtsFluidDSStrings.ts
 	 *
-	 * Provides an array of strings that need to be available for translation
-	 * in the JavaScript code.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 * @return array<string, string> Array of translatable strings.
+	 * @return array<string, string>
 	 */
 	private function get_localized_strings(): array {
 		return array(

--- a/src/php/Managers/ControlRegistry.php
+++ b/src/php/Managers/ControlRegistry.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Control Registry manager for Fluid Design System.
+ * Control ID generation and parsing for Elementor Kit controls.
+ *
+ * Control ID patterns:
+ * - Built-in: fluid_spacing_presets, fluid_typography_presets
+ * - Custom: fluid_custom_{group_id}_presets
  *
  * @package Arts\FluidDesignSystem
  * @since 1.0.0
@@ -9,76 +13,38 @@
 namespace Arts\FluidDesignSystem\Managers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 use Arts\Utilities\Utilities;
 
 /**
- * ControlRegistry Class
- *
- * Manages control ID generation and metadata for
- * Fluid Design System Elementor controls.
+ * Control ID generation and metadata registry.
  *
  * @since 1.0.0
  */
 class ControlRegistry extends BaseManager {
 
-	/**
-	 * Get control ID for custom group presets.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $group_id The custom group ID.
-	 * @return string The control ID.
-	 */
-	public static function get_custom_group_control_id( $group_id ) {
+	/** @param string $group_id */
+	public static function get_custom_group_control_id( $group_id ): string {
 		return 'fluid_custom_' . $group_id . '_presets';
 	}
 
-	/**
-	 * Get section ID for custom group presets.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $group_id The custom group ID.
-	 * @return string The section ID.
-	 */
-	public static function get_custom_group_section_id( $group_id ) {
+	/** @param string $group_id */
+	public static function get_custom_group_section_id( $group_id ): string {
 		return 'section_fluid_custom_' . $group_id . '_presets';
 	}
 
-	/**
-	 * Get info control ID for custom group presets.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $group_id The custom group ID.
-	 * @return string The info control ID.
-	 */
-	public static function get_custom_group_info_control_id( $group_id ) {
+	/** @param string $group_id */
+	public static function get_custom_group_info_control_id( $group_id ): string {
 		return 'fluid_custom_' . $group_id . '_presets_info';
 	}
 
 	/**
-	 * Get built-in group metadata for admin display.
+	 * Combines built-in and custom groups metadata. Single source of truth for labels.
 	 *
-	 * Returns an array mapping collection types to their display names and descriptions
-	 * as defined in the Elementor controls. This ensures a single source of truth
-	 * for group labels and descriptions.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @return array<string, array<string, mixed>> Array mapping collection types to display metadata.
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function get_builtin_group_metadata(): array {
 		$builtin_metadata = array(
@@ -92,28 +58,17 @@ class ControlRegistry extends BaseManager {
 			),
 		);
 
-		// Add custom groups metadata
 		$custom_groups = self::get_custom_groups_metadata();
 
 		return array_merge( $builtin_metadata, $custom_groups );
 	}
 
 	/**
-	 * Get custom group metadata for admin display.
+	 * Loads custom groups from wp_options, sorted by order field.
 	 *
-	 * Retrieves display names and descriptions for all custom preset groups
-	 * by loading the group data from the saved options. This dynamically
-	 * generates metadata for custom groups that have been created via the
-	 * admin interface.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @return array<string, array<string, mixed>> Array mapping custom group IDs to display metadata.
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function get_custom_groups_metadata(): array {
-		// Use WordPress option directly to avoid dependency issues
 		$custom_groups = Utilities::get_array_value( get_option( 'arts_fluid_design_system_custom_groups', array() ) );
 		$metadata      = array();
 
@@ -128,7 +83,6 @@ class ControlRegistry extends BaseManager {
 			);
 		}
 
-		// Sort by order field
 		uasort(
 			$metadata,
 			function ( $a, $b ) {
@@ -140,19 +94,13 @@ class ControlRegistry extends BaseManager {
 	}
 
 	/**
-	 * Get built-in control mappings for data managers.
+	 * Maps control IDs to their metadata for built-in groups.
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @return array<string, array<string, mixed>> Array mapping control IDs to group metadata.
+	 * @return array<string, array<string, mixed>>
 	 */
 	public static function get_builtin_control_mappings(): array {
-		// Get metadata from this registry
 		$metadata = self::get_builtin_group_metadata();
 
-		// Map control IDs to their metadata
 		return array(
 			'fluid_spacing_presets'    => $metadata['spacing'],
 			'fluid_typography_presets' => $metadata['typography'],
@@ -160,22 +108,18 @@ class ControlRegistry extends BaseManager {
 	}
 
 	/**
-	 * Get the control ID for a group from kit settings.
-	 *
-	 * @since 1.0.0
+	 * Resolves group_id to Kit control_id. Checks direct ID, then prefixed format.
 	 *
 	 * @param string $group_id Group ID to lookup.
-	 * @return string|false Control ID or false if not found.
+	 * @return string|false Control ID or false if not found in Kit settings.
 	 */
 	public static function get_kit_control_id( $group_id ) {
-		// Handle built-in groups
 		$builtin_mappings = self::get_builtin_control_mappings();
 
 		if ( isset( $builtin_mappings[ $group_id ] ) ) {
 			return $group_id;
 		}
 
-		// Handle custom groups
 		if ( ! Utilities::is_elementor_plugin_active() ) {
 			return false;
 		}
@@ -191,13 +135,12 @@ class ControlRegistry extends BaseManager {
 			return false;
 		}
 
-		// Try the group ID directly first
-		if ( isset( $kit_settings[ $group_id ] ) ) {
-			return $group_id;
+		$group_id_str = Utilities::get_string_value( $group_id );
+		if ( isset( $kit_settings[ $group_id_str ] ) ) {
+			return $group_id_str;
 		}
 
-		// Try with the fluid_custom_ prefix
-		$prefixed_id = self::get_custom_group_control_id( $group_id );
+		$prefixed_id = self::get_custom_group_control_id( $group_id_str );
 		if ( isset( $kit_settings[ $prefixed_id ] ) ) {
 			return $prefixed_id;
 		}
@@ -206,17 +149,12 @@ class ControlRegistry extends BaseManager {
 	}
 
 	/**
-	 * Parse a control ID to extract the group ID and type.
+	 * Parses control ID to extract type and group_id. Handles legacy format.
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $control_id The control ID to parse.
-	 * @return array<string, string>|false Array with 'type' and 'group_id' keys, or false if invalid.
+	 * @param string $control_id Control ID to parse.
+	 * @return array<string, string>|false Array with 'type' and 'group_id', or false.
 	 */
 	public static function parse_control_id( $control_id ) {
-		// Built-in controls
 		if ( $control_id === 'fluid_spacing_presets' ) {
 			return array(
 				'type'     => 'builtin',
@@ -231,7 +169,7 @@ class ControlRegistry extends BaseManager {
 			);
 		}
 
-		// Custom group controls: fluid_custom_{group_id}_presets
+		// Custom: fluid_custom_{group_id}_presets
 		if ( preg_match( '/^fluid_custom_(.+)_presets$/', $control_id, $matches ) ) {
 			return array(
 				'type'     => 'custom',
@@ -239,11 +177,10 @@ class ControlRegistry extends BaseManager {
 			);
 		}
 
-		// Legacy custom format: fluid_{group_id}_presets (excluding built-ins)
+		// Legacy: fluid_{group_id}_presets (excluding built-ins)
 		if ( preg_match( '/^fluid_(.+)_presets$/', $control_id, $matches ) ) {
 			$group_part = $matches[1];
 
-			// Skip if it matches built-in patterns
 			if ( in_array( $group_part, array( 'spacing', 'typography' ), true ) ) {
 				return false;
 			}
@@ -258,25 +195,18 @@ class ControlRegistry extends BaseManager {
 	}
 
 	/**
-	 * Generate a control ID from a group ID.
+	 * Auto-detects type if not provided. Cleans double prefixes.
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $group_id The group ID.
-	 * @param string $type The group type ('builtin' or 'custom').
-	 * @return string The control ID.
+	 * @param string      $group_id Group ID.
+	 * @param string|null $type     'builtin' or 'custom', null for auto-detect.
 	 */
-	public static function generate_control_id( $group_id, $type = null ) {
-		// If type not provided, try to detect it
+	public static function generate_control_id( $group_id, $type = null ): string {
 		if ( $type === null ) {
 			$builtin_mappings = self::get_builtin_control_mappings();
 			$type             = array_key_exists( 'fluid_' . $group_id . '_presets', $builtin_mappings ) ? 'builtin' : 'custom';
 		}
 
 		if ( $type === 'builtin' ) {
-			// Built-in groups use their standard format
 			if ( $group_id === 'spacing' ) {
 				return 'fluid_spacing_presets';
 			}
@@ -285,25 +215,15 @@ class ControlRegistry extends BaseManager {
 			}
 		}
 
-		// Custom groups need the fluid_custom_ prefix
-		// Remove any existing prefixes to avoid double prefixing
+		// Clean any existing prefixes to avoid double prefixing
 		$clean_id = preg_replace( '/^fluid_custom_/', '', $group_id );
 		$clean_id = preg_replace( '/_presets$/', '', $clean_id ?? '' );
 
 		return 'fluid_custom_' . $clean_id . '_presets';
 	}
 
-	/**
-	 * Validate if a control ID is valid for fluid preset storage.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 * @static
-	 *
-	 * @param string $control_id The control ID to validate.
-	 * @return bool True if valid, false otherwise.
-	 */
-	public static function is_valid_control_id( $control_id ) {
+	/** @param string $control_id */
+	public static function is_valid_control_id( $control_id ): bool {
 		$parsed = self::parse_control_id( $control_id );
 		return $parsed !== false;
 	}

--- a/src/php/Managers/Extension.php
+++ b/src/php/Managers/Extension.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Extension configuration manager for Fluid Design System.
+ * Elementor extension configuration.
  *
  * @package Arts\FluidDesignSystem
  * @since 1.0.0
@@ -9,31 +9,20 @@
 namespace Arts\FluidDesignSystem\Managers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 
 /**
- * Extension Class
- *
- * Manages Elementor configuration settings and strings for
- * the Fluid Design System extension.
+ * Version requirements and extension strings for Elementor.
  *
  * @since 1.0.0
  */
 class Extension extends BaseManager {
 	/**
-	 * Filter plugin configuration for the Elementor extension.
-	 *
-	 * Defines required Elementor and PHP versions for the extension.
-	 * Used as a WordPress filter callback.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<string, mixed> $config The config for the Elementor extension.
-	 * @return array<string, mixed> Modified configuration array.
+	 * @param array<string, mixed> $config ArtsElementorExtension config.
+	 * @return array<string, mixed>
 	 */
 	public function filter_plugin_config( array $config ): array {
 		$config['required_elementor_version'] = '3.27.0';
@@ -43,19 +32,11 @@ class Extension extends BaseManager {
 	}
 
 	/**
-	 * Get the strings for the Elementor extension.
-	 *
-	 * Sets the extension name that appears in the Elementor UI.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<string, mixed> $config The config for the Elementor extension.
-	 * @return array<string, mixed> Modified strings array.
+	 * @param array<string, mixed> $config ArtsElementorExtension strings.
+	 * @return array<string, mixed>
 	 */
 	public function get_strings( array $config ): array {
-		/* This shouldn't be translated */
-		$config['extension_name'] = 'Fluid Design System for Elementor';
+		$config['extension_name'] = 'Fluid Design System for Elementor'; // Not translated intentionally
 
 		return $config;
 	}

--- a/src/php/Managers/Options.php
+++ b/src/php/Managers/Options.php
@@ -1,15 +1,14 @@
 <?php
 /**
- * Options manager for Fluid Design System.
+ * Elementor Site Settings tab and plugin action links.
  *
  * @package Arts\FluidDesignSystem
- * @since 1.0.0
  */
 
 namespace Arts\FluidDesignSystem\Managers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\Utilities\Utilities;
@@ -17,25 +16,14 @@ use Arts\FluidDesignSystem\Base\Manager as BaseManager;
 use Arts\FluidDesignSystem\Elementor\Tabs\FluidTypographySpacing;
 
 /**
- * Options Class
- *
- * Manages Elementor site settings tabs and options
- * for the Fluid Design System.
- *
- * @since 1.0.0
+ * Site Settings tab registration and plugin links.
  */
 class Options extends BaseManager {
 	/**
-	 * Register the `Fluid Typography & Spacing` tab in Elementor site settings.
+	 * Hooked to elementor/kit/additional_settings_tabs.
 	 *
-	 * Adds a custom tab to Elementor site settings for managing
-	 * typography and spacing options.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<int|string, mixed> $tabs Array of Elementor site settings tabs.
-	 * @return array<int|string, mixed> Array of Elementor site settings tabs with our custom tab added.
+	 * @param array<int|string, mixed> $tabs
+	 * @return array<int|string, mixed>
 	 */
 	public function get_elementor_site_settings_tabs( array $tabs ): array {
 		$tabs[] = array(
@@ -46,25 +34,18 @@ class Options extends BaseManager {
 	}
 
 	/**
-	 * Add plugin action links.
+	 * Hooked to plugin_action_links_{plugin_basename}.
 	 *
-	 * Adds "Customize Presets" and "Manage Groups" links to the plugin's action links in the WordPress admin plugins page.
-	 *
-	 * @since 1.0.1
-	 * @access public
-	 *
-	 * @param array<int, string> $links Array of plugin action links.
-	 * @return array<int, string> Modified array of plugin action links.
+	 * @param array<int, string> $links
+	 * @return array<int, string>
 	 */
 	public function add_plugin_action_links( array $links ): array {
-		// Check if Elementor is active
 		if ( ! Utilities::is_elementor_plugin_active() ) {
 			return $links;
 		}
 
 		$new_links = array();
 
-		// Add "Customize Presets" link (opens in new tab)
 		$settings_url = Utilities::get_elementor_editor_site_settings_url( FluidTypographySpacing::TAB_ID );
 		if ( $settings_url ) {
 			$new_links[] = sprintf(
@@ -74,7 +55,6 @@ class Options extends BaseManager {
 			);
 		}
 
-		// Add "Manage Groups" link
 		$admin_url   = admin_url( 'admin.php?page=fluid-design-system' );
 		$new_links[] = sprintf(
 			'<a href="%s">%s</a>',
@@ -82,7 +62,6 @@ class Options extends BaseManager {
 			esc_html__( 'Manage', 'fluid-design-system-for-elementor' )
 		);
 
-		// Prepend our links to the existing ones
 		return array_merge( $new_links, $links );
 	}
 }

--- a/src/php/Managers/Units.php
+++ b/src/php/Managers/Units.php
@@ -1,15 +1,14 @@
 <?php
 /**
- * Units manager for Fluid Design System.
+ * Adds 'fluid' unit to eligible Elementor controls and optimizes clamp() output.
  *
  * @package Arts\FluidDesignSystem
- * @since 1.0.0
  */
 
 namespace Arts\FluidDesignSystem\Managers;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Elementor\Core\Common\Modules\Ajax\Module as Ajax;
@@ -20,37 +19,19 @@ use Elementor\Core\Kits\Controls\Repeater as Global_Style_Repeater;
 use Arts\FluidDesignSystem\Managers\CSSVariables;
 
 /**
- * Units Class
- *
- * Manages Elementor units for Fluid Design System,
- * handling the addition of fluid units to various controls.
- *
- * @since 1.0.0
+ * Fluid unit injection into Elementor controls.
  */
 class Units extends BaseManager {
-	/**
-	 * Register AJAX handlers for fluid units.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param Ajax $ajax_manager The Elementor AJAX manager.
-	 * @return void
-	 */
 	public function register_ajax_handlers( Ajax $ajax_manager ): void {
 		FluidUnitModule::instance()->register_ajax_actions( $ajax_manager );
 	}
 
 	/**
-	 * Modify control settings to add fluid unit.
+	 * Hooked to elementor/element/after_section_end. Injects 'fluid' into size_units.
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param \Elementor\Controls_Stack $element    The element instance.
-	 * @param string                    $section_id The section ID.
-	 * @param array<string, mixed>      $args       The section arguments.
-	 * @return void
+	 * @param \Elementor\Controls_Stack $element
+	 * @param string                    $section_id
+	 * @param array<string, mixed>      $args
 	 */
 	public function modify_control_settings( \Elementor\Controls_Stack $element, string $section_id, array $args ): void {
 		$controls_raw = $element->get_controls();
@@ -102,53 +83,25 @@ class Units extends BaseManager {
 			}
 		}
 
-		/**
-		 * Fires after fluid units have been added to default controls.
-		 *
-		 * Allows 3rd-party developers to modify or add controls
-		 * that should receive the fluid unit.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param \Elementor\Controls_Stack $element    The element instance.
-		 * @param string                    $section_id The section ID.
-		 * @param array<string, mixed>      $args       The section arguments.
-		 * @param self                      $units      The Units instance.
-		 */
+		/** Allows 3rd-party to modify controls after fluid unit injection. */
 		do_action( 'arts/fluid_design_system/controls/after_add_fluid_unit', $element, $section_id, $args, $this );
 	}
 
 	/**
-	 * Check if a control is eligible for adding the fluid unit.
+	 * Eligible controls have 'custom' in size_units (filterable).
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<string, mixed> $control The control configuration.
-	 * @return bool Whether the control is eligible.
+	 * @param array<string, mixed> $control
 	 */
 	public function is_control_eligible_for_fluid_unit( array $control ): bool {
 		$default_eligible = isset( $control['size_units'] ) && is_array( $control['size_units'] ) && in_array( 'custom', $control['size_units'], true );
 
-		/**
-		 * Filter whether a control is eligible for the fluid unit.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param bool  $default_eligible Default eligibility status.
-		 * @param array $control          The control configuration.
-		 */
-		return apply_filters( 'arts/fluid_design_system/controls/is_eligible_for_fluid_unit', $default_eligible, $control );
+		$filtered = apply_filters( 'arts/fluid_design_system/controls/is_eligible_for_fluid_unit', $default_eligible, $control );
+		return is_bool( $filtered ) ? $filtered : $default_eligible;
 	}
 
 	/**
-	 * Get eligible controls for fluid unit.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<string, array<string, mixed>> $controls The controls array.
-	 * @return array<string, array<string, mixed>> Filtered array of eligible controls.
+	 * @param array<string, array<string, mixed>> $controls
+	 * @return array<string, array<string, mixed>>
 	 */
 	public function get_eligible_controls_for_fluid_unit( array $controls ): array {
 		/** @var array<string, array<string, mixed>> $eligible_controls */
@@ -160,41 +113,25 @@ class Units extends BaseManager {
 			}
 		}
 
-		/**
-		 * Filter the eligible controls for fluid unit.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array<string, array<string, mixed>> $eligible_controls The eligible controls.
-		 * @param array<string, array<string, mixed>> $controls          All controls.
-		 */
 		$filtered = apply_filters( 'arts/fluid_design_system/controls/eligible_for_fluid_unit', $eligible_controls, $controls );
 		/** @var array<string, array<string, mixed>> $filtered */
 		return $filtered;
 	}
 
 	/**
-	 * Modify selectors for fluid units.
+	 * Hooked to elementor/element/parse_css. Strips {{UNIT}} for fluid values.
 	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param array<string, mixed>                  $control  The control configuration.
-	 * @param array<string, mixed>|string           $value    The control value.
-	 * @param \Elementor\Core\Files\CSS\Base|string $css_file The CSS file.
-	 * @return array<string, mixed> Modified control configuration.
+	 * @param array<string, mixed>                  $control
+	 * @param array<string, mixed>|string           $value
+	 * @param \Elementor\Core\Files\CSS\Base|string $css_file
+	 * @return array<string, mixed>
 	 */
 	public function modify_selectors( array $control, $value, $css_file ): array {
 		$eligible_control_types = array( 'slider', 'dimensions', 'gaps' );
 
-		/**
-		 * Filter the eligible control types for selector modification.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array<int, string> $eligible_control_types The eligible control types.
-		 */
-		$eligible_control_types = apply_filters( 'arts/fluid_design_system/controls/eligible_types_for_selector_modification', $eligible_control_types );
+		$filtered_types = apply_filters( 'arts/fluid_design_system/controls/eligible_types_for_selector_modification', $eligible_control_types );
+		/** @var array<int, string> $eligible_control_types */
+		$eligible_control_types = is_array( $filtered_types ) ? $filtered_types : $eligible_control_types;
 
 		if ( ! isset( $control['type'] ) || ! in_array( $control['type'], $eligible_control_types, true ) ) {
 			return $control;
@@ -215,17 +152,6 @@ class Units extends BaseManager {
 
 			$modified_css_property = str_replace( '{{UNIT}}', '', $css_property );
 
-			/**
-			 * Filter the modified CSS property for fluid units.
-			 *
-			 * @since 1.0.0
-			 *
-			 * @param string                            $modified_css_property The modified CSS property.
-			 * @param string                            $css_property          The original CSS property.
-			 * @param string                            $selector              The CSS selector.
-			 * @param array<string, mixed>              $control               The control configuration.
-			 * @param array<string, mixed>              $value                 The control value.
-			 */
 			$filtered_property                 = apply_filters(
 				'arts/fluid_design_system/controls/modified_css_property',
 				$modified_css_property,
@@ -241,20 +167,11 @@ class Units extends BaseManager {
 	}
 
 	/**
-	 * Optimize fluid CSS by simplifying clamp formulas with equal min/max values.
-	 *
-	 * @since 1.0.0
-	 * @access public
-	 *
-	 * @param \Elementor\Core\Files\CSS\Base $css_file The CSS file object.
-	 * @return void
+	 * Hooked to elementor/css-file/post-parse. Simplifies clamp() when min=max.
 	 */
 	public function optimize_fluid_css_post_parse( \Elementor\Core\Files\CSS\Base $css_file ): void {
-		// Get the stylesheet
 		$stylesheet = $css_file->get_stylesheet();
-
-		// Get the CSS rules
-		$all_rules = $stylesheet->get_rules();
+		$all_rules  = $stylesheet->get_rules();
 
 		if ( ! is_array( $all_rules ) || empty( $all_rules ) ) {
 			return;
@@ -262,13 +179,11 @@ class Units extends BaseManager {
 
 		$preset_prefix = CSSVariables::CSS_VAR_PRESET_PREFIX;
 
-		// Process each device's rules
 		foreach ( $all_rules as $device => $selectors ) {
 			if ( ! is_array( $selectors ) || empty( $selectors ) ) {
 				continue;
 			}
 
-			// Process each selector's properties
 			foreach ( $selectors as $selector => $properties ) {
 				if ( ! is_array( $properties ) || empty( $properties ) || ! is_string( $selector ) || $selector !== ':root' ) {
 					continue;
@@ -277,36 +192,27 @@ class Units extends BaseManager {
 				$optimized_properties = array();
 				$needs_update         = false;
 
-				// Process each property
 				foreach ( $properties as $property => $value ) {
 					if ( ! is_string( $property ) || ! is_string( $value ) ) {
 						$optimized_properties[ $property ] = $value;
 						continue;
 					}
 
-					// Check if this is a fluid preset property with a clamp formula
 					if ( strpos( $property, $preset_prefix ) === 0 && strpos( $value, 'clamp(' ) === 0 ) {
-						// Try to simplify the clamp formula
 						$simplified_value = $this->simplify_clamp_formula( $value );
 
 						if ( $simplified_value !== $value ) {
-							// Store the simplified value
 							$optimized_properties[ $property ] = $simplified_value;
 							$needs_update                      = true;
 						} else {
-							// Keep the original value
 							$optimized_properties[ $property ] = $value;
 						}
 					} else {
-						// Keep all non-fluid-preset properties unchanged
 						$optimized_properties[ $property ] = $value;
 					}
 				}
 
-				// Only update if we actually optimized something
 				if ( $needs_update ) {
-					// Use add_rules to update the properties for this selector
-					// The third parameter (query) should match what was used originally
 					$query = ( $device !== 'all' ) ? array() : null;
 					$stylesheet->add_rules( $selector, $optimized_properties, $query );
 				}
@@ -314,24 +220,13 @@ class Units extends BaseManager {
 		}
 	}
 
-	/**
-	 * Simplify a CSS clamp formula if min and max values are identical.
-	 *
-	 * @since 1.0.0
-	 * @access private
-	 *
-	 * @param string $css_value The CSS value to potentially simplify.
-	 * @return string The simplified value or original value if no simplification possible.
-	 */
+	/** Extracts clamp() bounds and returns static value if identical. */
 	private function simplify_clamp_formula( string $css_value ): string {
-		// Use a single regex to extract all three clamp parameters in one pass
 		if ( preg_match( '/^clamp\s*\(\s*min\s*\(\s*([^,]+?)\s*,\s*([^,]+?)\s*\)/', $css_value, $matches ) ) {
 			$min_value = trim( $matches[1] );
 			$max_value = trim( $matches[2] );
 
-			// If min and max values are identical, return just that value
 			if ( $min_value === $max_value ) {
-				// Also check if there's a zero difference calculation
 				if ( strpos( $css_value, ' - ' . preg_quote( str_replace( 'px', '', $min_value ) ) . ')' ) !== false ) {
 					return $min_value;
 				}

--- a/src/php/Plugin.php
+++ b/src/php/Plugin.php
@@ -1,74 +1,40 @@
 <?php
 /**
- * Main plugin class for Fluid Design System.
+ * Plugin initialization and hook registration.
  *
  * @package Arts\FluidDesignSystem
- * @since 1.0.0
  */
 
 namespace Arts\FluidDesignSystem;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+	exit;
 }
 
 use Arts\FluidDesignSystem\Base\Plugin as BasePlugin;
 
 /**
- * Plugin Class
- *
- * Main class that initializes the Fluid Design System plugin,
- * manages dependencies, and sets up hooks.
- *
- * @since 1.0.0
+ * Main plugin class - managers, actions, and filters.
  */
 class Plugin extends BasePlugin {
-	/**
-	 * Get default configuration for the plugin.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return array<string, mixed> Empty array as default configuration.
-	 */
+	/** @return array<string, mixed> */
 	protected function get_default_config(): array {
 		return array();
 	}
 
-	/**
-	 * Get default strings for the plugin.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return array<string, string> Empty array as default strings.
-	 */
+	/** @return array<string, string> */
 	protected function get_default_strings(): array {
 		return array();
 	}
 
-	/**
-	 * Get default WordPress action to run the plugin.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return string WordPress action name.
-	 */
 	protected function get_default_run_action(): string {
 		return 'init';
 	}
 
 	/**
-	 * Get manager classes for the plugin.
+	 * Keys become $this->managers->key accessors.
 	 *
-	 * Defines which manager classes should be instantiated
-	 * and made available through the $this->managers object.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return array<string, class-string> Associative array of manager keys and their corresponding class names.
+	 * @return array<string, class-string>
 	 */
 	protected function get_managers_classes(): array {
 		return array(
@@ -90,74 +56,28 @@ class Plugin extends BasePlugin {
 		);
 	}
 
-	/**
-	 * Actions to perform after initializing managers.
-	 *
-	 * Registers filters for Elementor extensions, configuration, and strings.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return void
-	 */
+	/** Registers filters for ArtsElementorExtension integration. */
 	protected function do_after_init_managers(): void {
-		// Register tabs for Elementor site settings
 		add_filter( 'arts/elementor_extension/tabs/tabs', array( $this->managers->options, 'get_elementor_site_settings_tabs' ) );
-
-		// Set up extension configuration
 		add_filter( 'arts/elementor_extension/plugin/config', array( $this->managers->extension, 'filter_plugin_config' ) );
-
-		// Set up extension strings
 		add_filter( 'arts/elementor_extension/plugin/strings', array( $this->managers->extension, 'get_strings' ) );
 	}
 
-	/**
-	 * Register WordPress actions for the plugin.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return void
-	 */
 	protected function add_actions(): void {
-		// Add fluid unit to Elementor controls
 		add_action( 'elementor/element/after_section_end', array( $this->managers->units, 'modify_control_settings' ), 10, 3 );
-
-		// Register fluid unit AJAX handlers for UI interactions
 		add_action( 'elementor/ajax/register_actions', array( $this->managers->units, 'register_ajax_handlers' ) );
-
-		// Add necessary scripts to Elementor editor
 		add_action( 'elementor/editor/before_enqueue_scripts', array( $this->managers->compatibility, 'elementor_enqueue_editor_scripts' ) );
-
-		// Add custom styles to Elementor editor
 		add_action( 'elementor/editor/after_enqueue_styles', array( $this->managers->compatibility, 'elementor_enqueue_editor_styles' ) );
-
-		// Optimize generated CSS to simplify fluid clamp formulas
 		add_action( 'elementor/css-file/post/parse', array( $this->managers->units, 'optimize_fluid_css_post_parse' ) );
-
-		// Add admin menu for preset groups management
 		add_action( 'admin_menu', array( $this->managers->admin_page, 'add_admin_menu' ), 80 );
-
-		// Enqueue admin assets
 		add_action( 'admin_enqueue_scripts', array( $this->managers->admin_frontend, 'enqueue_assets' ) );
-
-		// Add AJAX handler for admin operations
 		add_action( 'wp_ajax_fluid_design_system_admin_action', array( $this->managers->admin_tabs_groups_ajax, 'handle_ajax_requests' ) );
 	}
 
-
-	/**
-	 * Register WordPress filters for the plugin.
-	 *
-	 * @since 1.0.0
-	 * @access protected
-	 *
-	 * @return void
-	 */
 	protected function add_filters(): void {
 		add_filter( 'elementor/files/css/selectors', array( $this->managers->units, 'modify_selectors' ), 10, 3 );
 
-		// Only add plugin action links if the plugin is being used as a WordPress plugin
+		// Plugin action links only when used as standalone WP plugin
 		if ( defined( 'ARTS_FLUID_DS_PLUGIN_FILE' ) ) {
 			/** @var string $plugin_file */
 			$plugin_file = constant( 'ARTS_FLUID_DS_PLUGIN_FILE' );


### PR DESCRIPTION
## Summary
- Remove verbose PHPDoc blocks (`@since`, `@access` tags)
- Add file headers with `@package` documentation  
- Add explicit return types for PHPStan compliance
- Add defensive type checks for filter returns in `Units.php`

## Test plan
- [x] `composer check` passes