### PR TITLE
fix: update Codecov action to v5 with token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,10 +98,11 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit:run
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         if: always()
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/coverage-final.json
           flags: unittests
 


### PR DESCRIPTION
Use codecov-action@v5 with token for coverage uploads.

Codecov v4+ requires token even for public repositories.

Token configured via GitHub Secrets: CODECOV_TOKEN