### PR TITLE
fix(security): resolve CodeQL alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   # Extract changelog from readme.txt
   prepare-changelog:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   plugin-check:
     name: WordPress.org Plugin Check

--- a/src/php/admin/js/base.js
+++ b/src/php/admin/js/base.js
@@ -24,15 +24,16 @@
    * Decode HTML entities and convert escaped newlines to actual newlines
    */
   function decodeHtmlString(str) {
-    if (!str) return str
+    if (!str) { return str }
 
+    // Decode &amp; LAST to prevent double-unescaping
     return str
       .replace(/&quot;/g, '"')
       .replace(/&#039;/g, "'")
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/\\n/g, '\n')
+      .replace(/&amp;/g, '&')
   }
 
   /**
@@ -655,11 +656,15 @@
    * Sanitize input to prevent XSS attacks
    */
   function sanitizeInput(input) {
-    // Remove HTML tags and dangerous characters
-    return input
-      .replace(/<[^>]*>/g, '') // Remove HTML tags
-      .replace(/[<>"'&]/g, '') // Remove dangerous characters
-      .trim()
+    // Apply tag removal repeatedly until stable (prevents nested tag bypass)
+    let result = input
+    let prev
+    do {
+      prev = result
+      result = result.replace(/<[^>]*>/g, '')
+    } while (result !== prev)
+    // Remove dangerous characters
+    return result.replace(/[<>"'&]/g, '').trim()
   }
 
   /**

--- a/src/php/admin/js/inline-editing.js
+++ b/src/php/admin/js/inline-editing.js
@@ -213,11 +213,15 @@
    * Sanitize input to prevent XSS attacks
    */
   function sanitizeInput(input) {
-    // Remove HTML tags and dangerous characters
-    return input
-      .replace(/<[^>]*>/g, '') // Remove HTML tags
-      .replace(/[<>"'&]/g, '') // Remove dangerous characters
-      .trim()
+    // Apply tag removal repeatedly until stable (prevents nested tag bypass)
+    let result = input
+    let prev
+    do {
+      prev = result
+      result = result.replace(/<[^>]*>/g, '')
+    } while (result !== prev)
+    // Remove dangerous characters
+    return result.replace(/[<>"'&]/g, '').trim()
   }
 
   /**

--- a/src/php/admin/js/status-notices.js
+++ b/src/php/admin/js/status-notices.js
@@ -181,13 +181,14 @@
     }
 
     // Decode HTML entities that might come from WordPress localization
+    // Decode &amp; LAST to prevent double-unescaping
     message = message
       .replace(/&quot;/g, '"')
       .replace(/&#039;/g, "'")
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/\\n/g, '\n')
+      .replace(/&amp;/g, '&')
 
     return message
   }

--- a/src/ts/utils/templates.ts
+++ b/src/ts/utils/templates.ts
@@ -4,6 +4,14 @@ import type { TSelect2State } from '../types'
 
 /** HTML template generation utilities for Select2 preset options */
 export class TemplateRenderer {
+  /** Escapes HTML special characters to prevent XSS */
+  private static escapeHtml(str: string | null | undefined): string {
+    if (!str) { return '' }
+    const div = document.createElement('div')
+    div.textContent = str
+    return div.innerHTML
+  }
+
   /** Creates a base template container */
   static createBaseTemplate(className: string = '', content: string = ''): JQuery<HTMLElement> {
     return jQuery(`
@@ -49,7 +57,7 @@ export class TemplateRenderer {
   /** Creates simple inherit template */
   static createSimpleInheritTemplate(element: HTMLElement, text: string): JQuery<HTMLElement> {
     const inheritedTitle =
-      element.getAttribute('data-inherited-title') || text || window.ArtsFluidDSStrings?.inherit
+      TemplateRenderer.escapeHtml(element.getAttribute('data-inherited-title')) || text || window.ArtsFluidDSStrings?.inherit
 
     return TemplateRenderer.createBaseTemplate(
       'select2-result-fluid-spacing-formatted--inherit',
@@ -100,7 +108,7 @@ export class TemplateRenderer {
 
   /** Handles empty value template */
   static handleEmptyValueTemplate(element: HTMLElement, text: string): JQuery<HTMLElement> {
-    const valueDisplay = element.getAttribute('data-value-display')
+    const valueDisplay = TemplateRenderer.escapeHtml(element.getAttribute('data-value-display'))
 
     if (valueDisplay) {
       const isInheritedPreset = element.getAttribute('data-inherited-preset')
@@ -126,7 +134,7 @@ export class TemplateRenderer {
     const minUnit = element.getAttribute('data-min-unit')
     const maxSize = element.getAttribute('data-max-size')
     const maxUnit = element.getAttribute('data-max-unit')
-    const inheritedTitle = element.getAttribute('data-inherited-title')
+    const inheritedTitle = TemplateRenderer.escapeHtml(element.getAttribute('data-inherited-title'))
 
     // For simple values without min/max sizes
     if (!minSize || !maxSize) {
@@ -192,7 +200,7 @@ export class TemplateRenderer {
     const headerContent = ValueFormatter.formatSizeRange(minSize, minUnit, maxSize, maxUnit, {
       includeSpan: true
     })
-    const inheritedTitle = element.getAttribute('data-inherited-title')
+    const inheritedTitle = TemplateRenderer.escapeHtml(element.getAttribute('data-inherited-title'))
 
     const markup = TemplateRenderer.createBaseTemplate(
       'select2-result-fluid-spacing-formatted--inherit',
@@ -315,13 +323,13 @@ export class TemplateRenderer {
   ): JQuery<HTMLElement> {
     const isInheritedPreset = element.getAttribute('data-inherited-preset')
     const isInheritedValue = element.getAttribute('data-inherited-value')
-    const title = element.getAttribute('data-title') || ''
+    const title = TemplateRenderer.escapeHtml(element.getAttribute('data-title')) || ''
     const minSize = element.getAttribute('data-min-size') || ''
     const minUnit = element.getAttribute('data-min-unit') || ''
     const maxSize = element.getAttribute('data-max-size') || ''
     const maxUnit = element.getAttribute('data-max-unit') || ''
-    const valueDisplay = element.getAttribute('data-value-display') || ''
-    const customDisplayValue = element.getAttribute('data-display-value') || ''
+    const valueDisplay = TemplateRenderer.escapeHtml(element.getAttribute('data-value-display')) || ''
+    const customDisplayValue = TemplateRenderer.escapeHtml(element.getAttribute('data-display-value')) || ''
 
     if (isInheritedValue) {
       return TemplateRenderer.createInheritedValueTemplate(element, valueDisplay, title)


### PR DESCRIPTION
Fixes all 16 CodeQL security alerts:

- Loop-based sanitization to prevent nested tag bypass
- Decode `&amp;` last to prevent double-unescaping  
- Escape DOM attribute values before HTML interpolation
- Add workflow permissions blocks

https://github.com/artkrsk/fluid-design-system-for-elementor/security/code-scanning