### PR TITLE
Fix e2e flakiness: HTTP-level setup login, single CI job, condition-based waits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,15 +187,15 @@ jobs:
           flags: unittests
 
   e2e-tests:
-    name: E2E Tests (${{ matrix.browser }})
+    name: E2E Tests
     needs: plugin-check
     runs-on: self-hosted
-    strategy:
-      # One browser failing means the change is broken; cancel the rest so the
-      # single self-hosted runner isn't wasted on runs that can't pass anyway.
-      fail-fast: true
-      matrix:
-        browser: [chromium, firefox, webkit]
+    # The host has multiple runner slots but wp-env always binds 8888/8889, so
+    # e2e jobs from different runs must never overlap. cancel-in-progress stays
+    # off — a running suite finishes; a superseded queued job may be cancelled.
+    concurrency:
+      group: wp-env-e2e-host
+      cancel-in-progress: false
     steps:
       - name: Disable git hooks
         run: git config --global core.hooksPath /dev/null
@@ -237,14 +237,10 @@ jobs:
 
       - name: Install Playwright system dependencies
         if: runner.environment == 'github-hosted'
-        run: npx playwright install-deps ${{ matrix.browser }}
+        run: npx playwright install-deps chromium firefox webkit
 
       - name: Install Playwright browsers
-        run: |
-          npx playwright install ${{ matrix.browser }}
-          if [ "${{ matrix.browser }}" != "chromium" ]; then
-            npx playwright install chromium
-          fi
+        run: npx playwright install chromium firefox webkit
 
       - name: Destroy previous wp-env
         # Bound the teardown so a wp-env/Docker hang can't wedge the runner (||true ignores
@@ -255,7 +251,15 @@ jobs:
         run: npm run wp-env start
 
       - name: Run E2E tests
-        run: npx playwright test --project=${{ matrix.browser }}
+        # All three browser projects in one invocation: one build, one wp-env,
+        # one global setup. maxFailures in playwright.config.ts keeps fail-fast.
+        run: npx playwright test
+
+      - name: Dump environment diagnostics
+        if: failure()
+        run: |
+          docker ps -a || true
+          npm run wp-env run cli -- tail -n 100 /var/www/html/wp-content/debug.log || true
 
       - name: Stop wp-env
         if: always()
@@ -265,7 +269,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: playwright-report-${{ matrix.browser }}
+          name: playwright-report
           path: playwright-report/
           retention-days: 30
 
@@ -273,6 +277,6 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: playwright-videos-${{ matrix.browser }}
+          name: playwright-videos
           path: test-results/
           retention-days: 7

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -12,7 +12,10 @@
   "config": {
     "WP_DEBUG": true,
     "SCRIPT_DEBUG": true,
-    "WP_DEBUG_LOG": true
+    "WP_DEBUG_LOG": true,
+    "WP_HTTP_BLOCK_EXTERNAL": true,
+    "WP_ACCESSIBLE_HOSTS": "localhost,127.0.0.1",
+    "AUTOMATIC_UPDATER_DISABLED": true
   },
   "port": 8888,
   "testsPort": 8889

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,4 +1,4 @@
-import { chromium, FullConfig } from '@playwright/test'
+import { request, FullConfig } from '@playwright/test'
 import { execSync } from 'child_process'
 import * as path from 'path'
 import { fileURLToPath } from 'url'
@@ -12,6 +12,8 @@ const WP_PASSWORD = process.env.WP_PASSWORD || 'password'
 /** Plugin path inside wp-env container */
 const PLUGIN_PATH =
   '/var/www/html/wp-content/plugins/fluid-design-system-for-elementor'
+
+const STORAGE_STATE_PATH = './tests/e2e/.auth/admin.json'
 
 async function globalSetup(config: FullConfig) {
   const { baseURL } = config.projects[0]!.use
@@ -27,65 +29,188 @@ async function globalSetup(config: FullConfig) {
   // Step 3: Create test page via WP-CLI
   await createTestPage()
 
-  // Step 3: Login and save auth state
-  const browser = await chromium.launch()
-  const context = await browser.newContext()
-  const page = await context.newPage()
+  // Step 4: Verify wp-env activated all plugins; clear Elementor's one-time
+  // activation redirect so it can't hijack the first admin navigation
+  verifyPluginsActive()
 
-  console.log(`[E2E Setup] Logging into WordPress at ${baseURL}`)
-
-  try {
-    // Login to WordPress
-    await page.goto(`${baseURL}/wp-login.php`)
-    await page.fill('#user_login', WP_USERNAME)
-    await page.fill('#user_pass', WP_PASSWORD)
-    await page.click('#wp-submit')
-
-    // Confirm the login redirect landed. Wait only for `domcontentloaded`, not the
-    // default `load` — the full dashboard load is slow on the CI runner (and we
-    // navigate away to plugins.php next anyway), which made this flaky in Firefox.
-    await page.waitForURL('**/wp-admin/**', { timeout: 60000, waitUntil: 'domcontentloaded' })
-    console.log('[E2E Setup] Successfully logged in')
-
-    // Activate plugin if not already active
-    await page.goto(`${baseURL}/wp-admin/plugins.php`)
-    const pluginRow = page.locator(
-      'tr[data-slug="fluid-design-system-for-elementor"]:not(.plugin-update-tr)'
-    )
-
-    if ((await pluginRow.count()) > 0) {
-      const activateLink = pluginRow.locator('a.activate')
-      if ((await activateLink.count()) > 0) {
-        await activateLink.click()
-        await page.waitForLoadState('load')
-        console.log('[E2E Setup] Activated Fluid Design System plugin')
-      } else {
-        console.log('[E2E Setup] Plugin already active')
-      }
-    }
-
-    // Activate Elementor if not already active
-    const elementorRow = page.locator('tr[data-slug="elementor"]:not(.plugin-update-tr)')
-    if ((await elementorRow.count()) > 0) {
-      const activateLink = elementorRow.locator('a.activate')
-      if ((await activateLink.count()) > 0) {
-        await activateLink.click()
-        await page.waitForLoadState('load')
-        console.log('[E2E Setup] Activated Elementor plugin')
-      }
-    }
-
-    // Save authentication state
-    await context.storageState({ path: './tests/e2e/.auth/admin.json' })
-    console.log('[E2E Setup] Saved authentication state')
-  } catch (error) {
-    console.error('[E2E Setup] Setup failed:', error)
-    throw error
-  } finally {
-    await browser.close()
-  }
+  // Step 5: Login over HTTP (no browser) and save auth state
+  await loginAndSaveState(baseURL!)
 
   console.log('[E2E Setup] Global setup complete!')
+}
+
+/**
+ * Log into WordPress with plain HTTP requests and persist the auth cookies as
+ * a Playwright storage state usable by every browser project.
+ *
+ * A UI login (fill wp-login form, wait for the redirect to load) was flaky on
+ * the CI runner: the first /wp-admin/ page load could stall past 60s. Cookies
+ * are all the tests need, so obtain them at the protocol level instead.
+ */
+async function loginAndSaveState(baseURL: string): Promise<void> {
+  console.log(`[E2E Setup] Logging into WordPress at ${baseURL}`)
+
+  const context = await request.newContext({ baseURL })
+
+  try {
+    // Readiness poll: the web container may still be warming up even when the
+    // CLI container is already responsive. Doubles as the wordpress_test_cookie
+    // preflight — wp-login.php sets it on GET and requires it on POST.
+    await waitForHttpOk(context, '/wp-login.php', 10, 3000)
+
+    // Login POST with a few attempts; success = a wordpress_logged_in_* cookie
+    // in the jar (redirects are followed automatically, cookies retained).
+    let loggedIn = false
+    for (let attempt = 1; attempt <= 3 && !loggedIn; attempt++) {
+      const response = await context.post('/wp-login.php', {
+        form: {
+          log: WP_USERNAME,
+          pwd: WP_PASSWORD,
+          'wp-submit': 'Log In',
+          testcookie: '1',
+          redirect_to: `${baseURL}/wp-admin/`
+        }
+      })
+
+      const { cookies } = await context.storageState()
+      loggedIn = cookies.some(cookie =>
+        cookie.name.startsWith('wordpress_logged_in_')
+      )
+
+      if (!loggedIn) {
+        const body = await response.text()
+        console.error(
+          `[E2E Setup] Login attempt ${attempt}/3 failed: ` +
+            `HTTP ${response.status()} ${response.url()}\n` +
+            `Body snippet: ${body.replace(/\s+/g, ' ').slice(0, 500)}`
+        )
+        await new Promise(resolve => setTimeout(resolve, 2000))
+      }
+    }
+
+    if (!loggedIn) {
+      logEnvironmentDiagnostics()
+      throw new Error(
+        '[E2E Setup] Login failed: no wordpress_logged_in_* cookie after 3 attempts'
+      )
+    }
+    console.log('[E2E Setup] Successfully logged in')
+
+    // Authenticated warmup: proves the cookies work end-to-end, absorbs any
+    // one-time admin redirect, warms the admin PHP path before the first test,
+    // and times the exact request that used to stall the old UI login.
+    const start = Date.now()
+    const admin = await context.get('/wp-admin/')
+    const elapsed = Date.now() - start
+    const adminBody = await admin.text()
+
+    if (!admin.ok() || !adminBody.includes('wpadminbar')) {
+      logEnvironmentDiagnostics()
+      throw new Error(
+        `[E2E Setup] Authenticated /wp-admin/ check failed: HTTP ${admin.status()} ` +
+          `${admin.url()} in ${elapsed}ms\n` +
+          `Body snippet: ${adminBody.replace(/\s+/g, ' ').slice(0, 500)}`
+      )
+    }
+    console.log(`[E2E Setup] Warmed up /wp-admin/ in ${elapsed}ms`)
+
+    await context.storageState({ path: STORAGE_STATE_PATH })
+    console.log('[E2E Setup] Saved authentication state')
+  } finally {
+    await context.dispose()
+  }
+}
+
+/** Poll a URL until it responds 200, logging failures along the way */
+async function waitForHttpOk(
+  context: Awaited<ReturnType<typeof request.newContext>>,
+  url: string,
+  attempts: number,
+  delayMs: number
+): Promise<void> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await context.get(url)
+      if (response.ok()) {
+        return
+      }
+      console.log(
+        `[E2E Setup] Waiting for ${url}: HTTP ${response.status()} (attempt ${attempt}/${attempts})`
+      )
+    } catch (error) {
+      console.log(
+        `[E2E Setup] Waiting for ${url}: ${(error as Error).message} (attempt ${attempt}/${attempts})`
+      )
+    }
+    await new Promise(resolve => setTimeout(resolve, delayMs))
+  }
+  logEnvironmentDiagnostics()
+  throw new Error(`[E2E Setup] ${url} did not respond 200 after ${attempts} attempts`)
+}
+
+/** Best-effort environment state dump so CI failures are diagnosable from the log */
+function logEnvironmentDiagnostics(): void {
+  const commands = [
+    'docker ps',
+    'npm run wp-env run cli -- wp option get siteurl',
+    'npm run wp-env run cli -- tail -n 50 /var/www/html/wp-content/debug.log'
+  ]
+
+  for (const command of commands) {
+    try {
+      const output = execSync(command, {
+        cwd: path.resolve(__dirname, '../..'),
+        timeout: 60000
+      })
+      console.error(`[E2E Diagnostics] $ ${command}\n${output.toString().trim()}`)
+    } catch (error) {
+      console.error(`[E2E Diagnostics] $ ${command} failed: ${(error as Error).message}`)
+    }
+  }
+}
+
+/**
+ * Assert wp-env auto-activated every plugin from .wp-env.json and delete
+ * Elementor's activation-redirect transient. The old UI-based activation via
+ * plugins.php is gone: without a browser in setup, Elementor's one-time
+ * redirect would otherwise land on the first test navigation instead.
+ */
+function verifyPluginsActive(): void {
+  console.log('[E2E Setup] Verifying active plugins...')
+
+  const activePlugins = execSync(
+    `npm run wp-env run cli -- wp plugin list --status=active --field=name`,
+    {
+      cwd: path.resolve(__dirname, '../..'),
+      timeout: 60000
+    }
+  ).toString()
+
+  // Elementor's directory name follows the downloaded zip (elementor.latest-stable)
+  const required = ['fluid-design-system-for-elementor', 'elementor']
+  const missing = required.filter(name => !activePlugins.includes(name))
+  if (missing.length > 0) {
+    throw new Error(
+      `[E2E Setup] Expected wp-env to auto-activate plugins, but missing: ${missing.join(', ')}.\n` +
+        `Active plugins:\n${activePlugins}`
+    )
+  }
+
+  try {
+    execSync(
+      `npm run wp-env run cli -- wp transient delete elementor_activation_redirect`,
+      {
+        cwd: path.resolve(__dirname, '../..'),
+        stdio: 'ignore',
+        timeout: 60000
+      }
+    )
+  } catch {
+    // Transient may simply not exist — the authenticated warmup request
+    // absorbs any residual redirect either way.
+  }
+
+  console.log('[E2E Setup] Plugins active')
 }
 
 /**

--- a/tests/e2e/pages/elementor-editor.ts
+++ b/tests/e2e/pages/elementor-editor.ts
@@ -17,6 +17,24 @@ export class ElementorEditorPage {
     await this.page.waitForSelector('#elementor-panel', { timeout: 30000 })
     // Wait for preview frame
     await this.previewFrame.locator('body').waitFor({ timeout: 30000 })
+    // Wait for attach-preview to finish: document-switching commands (e.g.
+    // panel/global/open) dereference documents.getCurrent().$element via
+    // exitPreviewMode(), and Elementor populates $element asynchronously
+    // after the panel and preview DOM above already exist
+    await this.page.waitForFunction(
+      () => {
+        const doc = (
+          window as unknown as {
+            elementor?: {
+              documents?: { getCurrent?: () => { $element?: { length: number } } }
+            }
+          }
+        ).elementor?.documents?.getCurrent?.()
+        return Boolean(doc && doc.$element && doc.$element.length)
+      },
+      undefined,
+      { timeout: 30000 }
+    )
   }
 
   /** Open Elementor editor for a specific post */
@@ -65,14 +83,16 @@ export class ElementorEditorPage {
 
     // First click to show the edit overlay
     await widget.click()
-    await this.page.waitForTimeout(200)
 
-    // Click the edit button in the overlay (pen/pencil icon)
-    const editButton = widget.locator('.elementor-editor-element-edit, [data-event="edit"]')
-    if (await editButton.count() > 0) {
+    // Click the edit button in the overlay (pen/pencil icon); fall back to
+    // double-clicking the widget if the overlay never shows up
+    const editButton = widget
+      .locator('.elementor-editor-element-edit, [data-event="edit"]')
+      .first()
+    try {
+      await editButton.waitFor({ state: 'visible', timeout: 2000 })
       await editButton.click()
-    } else {
-      // Fallback: double-click the widget directly
+    } catch {
       await widget.dblclick()
     }
 
@@ -99,10 +119,11 @@ export class ElementorEditorPage {
     const toggle = section.locator('.elementor-panel-heading-toggle')
 
     // Check if already expanded
-    const isExpanded = await section.locator('.elementor-panel-heading').getAttribute('aria-expanded')
+    const heading = section.locator('.elementor-panel-heading')
+    const isExpanded = await heading.getAttribute('aria-expanded')
     if (isExpanded !== 'true') {
       await toggle.click()
-      await this.page.waitForTimeout(300)
+      await expect(heading).toHaveAttribute('aria-expanded', 'true')
     }
   }
 
@@ -128,8 +149,13 @@ export class ElementorEditorPage {
     const option = this.page.locator(`.select2-results__option:has-text("${presetName}")`)
     await option.click()
 
-    // Wait for dropdown to close
-    await this.page.waitForTimeout(300)
+    // Wait for the dropdown to close and the selection to render
+    await this.page
+      .locator('.select2-results')
+      .waitFor({ state: 'hidden', timeout: 5000 })
+    await expect(control.locator('.select2-selection__rendered')).toContainText(
+      presetName
+    )
   }
 
   /** Switch responsive device mode */

--- a/tests/e2e/specs/01-namespace-conflict.spec.ts
+++ b/tests/e2e/specs/01-namespace-conflict.spec.ts
@@ -97,14 +97,18 @@ test.describe('Namespace Conflict Handling', () => {
     if (!fdsIsActive) {
       const activateLink = fdsPluginRow.locator('.activate a')
       if (await activateLink.isVisible()) {
-        const [response] = await Promise.all([
-          page.waitForNavigation(),
-          activateLink.click()
-        ])
+        // Arm the response wait before clicking (waitForNavigation is deprecated)
+        const responsePromise = page.waitForResponse(
+          response =>
+            response.url().includes('plugins.php') &&
+            response.request().isNavigationRequest()
+        )
+        await activateLink.click()
+        const response = await responsePromise
 
         // Activation should not cause 500 error
         expect(
-          response?.status(),
+          response.status(),
           'Plugin activation should not cause fatal error'
         ).toBeLessThan(500)
       }

--- a/tests/e2e/specs/03-fluid-values.spec.ts
+++ b/tests/e2e/specs/03-fluid-values.spec.ts
@@ -110,14 +110,11 @@ test.describe('Fluid Spacing', () => {
     )
     expect(heightMobile).toBeCloseTo(getExpectedValue('e2e_gap_standard', 360), VALUE_TOLERANCE)
 
-    // At max viewport
+    // At max viewport (poll: the resize repaint lands asynchronously)
     await page.setViewportSize(TEST_VIEWPORTS.desktop)
-    // Need to wait for repaint
-    await page.waitForTimeout(100)
-    const heightDesktop = await spacer.evaluate(
-      el => parseFloat(getComputedStyle(el).height)
-    )
-    expect(heightDesktop).toBeCloseTo(getExpectedValue('e2e_gap_standard', 1920), VALUE_TOLERANCE)
+    await expect
+      .poll(() => spacer.evaluate(el => parseFloat(getComputedStyle(el).height)))
+      .toBeCloseTo(getExpectedValue('e2e_gap_standard', 1920), VALUE_TOLERANCE)
   })
 
   test('container gap scales with viewport', async ({ page }) => {
@@ -130,13 +127,11 @@ test.describe('Fluid Spacing', () => {
     )
     expect(gapMobile).toBeCloseTo(getExpectedValue('e2e_gap_large', 360), VALUE_TOLERANCE)
 
-    // At max viewport
+    // At max viewport (poll: the resize repaint lands asynchronously)
     await page.setViewportSize(TEST_VIEWPORTS.desktop)
-    await page.waitForTimeout(100)
-    const gapDesktop = await container.evaluate(
-      el => parseFloat(getComputedStyle(el).gap)
-    )
-    expect(gapDesktop).toBeCloseTo(getExpectedValue('e2e_gap_large', 1920), VALUE_TOLERANCE)
+    await expect
+      .poll(() => container.evaluate(el => parseFloat(getComputedStyle(el).gap)))
+      .toBeCloseTo(getExpectedValue('e2e_gap_large', 1920), VALUE_TOLERANCE)
   })
 })
 
@@ -150,16 +145,18 @@ test.describe('Viewport Transition', () => {
 
     for (const width of viewportWidths) {
       await page.setViewportSize({ width, height: 800 })
-      await page.waitForTimeout(50) // Allow repaint
+
+      // Poll until the resize repaint settles on the expected value, then
+      // record the settled reading for the monotonicity check below
+      const expected = calculateExpectedValue(24, 64, width)
+      await expect
+        .poll(() => heading.evaluate(el => parseFloat(getComputedStyle(el).fontSize)))
+        .toBeCloseTo(expected, VALUE_TOLERANCE)
 
       const fontSize = await heading.evaluate(
         el => parseFloat(getComputedStyle(el).fontSize)
       )
-
-      const expected = calculateExpectedValue(24, 64, width)
       results.push({ width, fontSize, expected })
-
-      expect(fontSize).toBeCloseTo(expected, VALUE_TOLERANCE)
     }
 
     // Verify values are monotonically increasing

--- a/tests/e2e/specs/06-edge-cases.spec.ts
+++ b/tests/e2e/specs/06-edge-cases.spec.ts
@@ -93,9 +93,12 @@ test.describe('Inverted Min/Max (min > max)', () => {
       el => parseFloat(getComputedStyle(el).fontSize)
     )
 
-    // At large viewport
+    // At large viewport: poll until the resize repaint settles on the
+    // expected value, then read the settled reading
     await page.setViewportSize(TEST_VIEWPORTS.desktop)
-    await page.waitForTimeout(100)
+    await expect
+      .poll(() => heading.evaluate(el => parseFloat(getComputedStyle(el).fontSize)))
+      .toBeCloseTo(getExpectedValue('e2e_inverted', 1920), VALUE_TOLERANCE)
     const largeValue = await heading.evaluate(
       el => parseFloat(getComputedStyle(el).fontSize)
     )

--- a/tests/e2e/specs/07-preview-switcher.spec.ts
+++ b/tests/e2e/specs/07-preview-switcher.spec.ts
@@ -15,9 +15,6 @@ import { test, expect } from '../fixtures'
 import type { Page } from '@playwright/test'
 import { TEST_ELEMENT_IDS } from '../fixtures/test-data'
 
-/** Time for the preview wrapper's width transition to settle (CSS is 0.2s) */
-const TRANSITION_MS = 350
-
 /** Rendered width of the editor preview wrapper (top frame), rounded */
 function previewWrapperWidth(page: Page): Promise<number> {
   return page.evaluate(() => {
@@ -42,9 +39,14 @@ function visibleSwitcher(page: Page) {
 }
 
 test.describe('Preview-width switcher', () => {
-  test.beforeEach(async ({ editor, testPageId }) => {
+  test.beforeEach(async ({ editor, testPageId, page }) => {
     await editor.openPost(testPageId)
     await editor.selectWidget(`#${TEST_ELEMENT_IDS.spacerStandard}`)
+    // The wrapper's width transition isn't under test — disable it so width
+    // changes settle instantly instead of sleeping through the animation
+    await page.addStyleTag({
+      content: '#elementor-preview-responsive-wrapper { transition: none !important; }'
+    })
   })
 
   test('renders Min/Max/Reset for a fluid control', async ({ page }) => {
@@ -63,13 +65,13 @@ test.describe('Preview-width switcher', () => {
     await switcher.locator('[data-anchor="max"]').click()
     expect(await previewIsActive(page)).toBe(true)
     expect(await previewWidthVar(page)).toBe('1920px')
-    await page.waitForTimeout(TRANSITION_MS)
+    await expect.poll(() => previewWrapperWidth(page)).toBeGreaterThan(360)
     const maxWidth = await previewWrapperWidth(page)
 
     // Min anchor (360) always fits, so the wrapper actually shrinks to it
     await switcher.locator('[data-anchor="min"]').click()
     expect(await previewWidthVar(page)).toBe('360px')
-    await page.waitForTimeout(TRANSITION_MS)
+    await expect.poll(() => previewWrapperWidth(page)).toBe(360)
     const minWidth = await previewWrapperWidth(page)
 
     expect(minWidth).toBe(360)
@@ -79,8 +81,9 @@ test.describe('Preview-width switcher', () => {
     await switcher.locator('[data-anchor="reset"]').click()
     expect(await previewIsActive(page)).toBe(false)
     expect(await previewWidthVar(page)).toBe('')
-    await page.waitForTimeout(TRANSITION_MS)
-    expect(Math.abs((await previewWrapperWidth(page)) - initialWidth)).toBeLessThanOrEqual(2)
+    await expect
+      .poll(async () => Math.abs((await previewWrapperWidth(page)) - initialWidth))
+      .toBeLessThanOrEqual(2)
   })
 
   test('device mode stays Desktop while previewing (no real switch)', async ({ page }) => {


### PR DESCRIPTION
The e2e suite has been failing intermittently for a while — most recently run 28684022277, where the webkit leg timed out in global setup waiting for the wp-admin redirect. Digging through the run history showed the flakiness never came from the tests themselves but from three independent causes.

First, the global-setup UI login. The first `/wp-admin/` load after login fires WordPress update checks against api.wordpress.org, and PHP inside the wp-env container hangs on the runner's broken network path — Node got the `ipv4first` fix a while back, PHP never did. That's why raising the login timeout twice (30s, then 60s) changed nothing: the navigation wasn't slow, it was stuck. wp-env now sets `WP_HTTP_BLOCK_EXTERNAL` (loopback stays allowed), which makes those calls fail in 0ms instead of hanging, and global setup no longer launches a browser at all. Login is a plain HTTP POST to wp-login.php with retries and a cookie assertion, followed by an authenticated `/wp-admin/` warmup that now takes ~100ms — the exact request that used to stall past 60s. When something does go wrong, setup dumps the response snippet, `docker ps` and the WP debug log, so the next incident is diagnosable straight from the CI log instead of being a bare timeout. The old plugins.php activation block is gone too: wp-env auto-activates listed plugins, and its `data-slug="elementor"` selector never matched the actual `elementor.latest-stable` folder anyway.

Second, the CI topology. Matrix legs from the same run can land on different runner slots of the same host, and every leg binds ports 8888/8889 with a hash-scoped wp-env that can't clean up its sibling's containers — the 2.5.0 release run failed exactly this way. The three-leg matrix is now a single job: one build, one wp-env, one `npx playwright test` across all three browser projects, so global setup runs once per run instead of three times and ports can't be contended within a run. A job-level concurrency group serializes e2e across runs, and `maxFailures` in the Playwright config preserves the fail-fast behavior the matrix used to provide.

Third, timing races in the tests. Every `waitForTimeout` in tests/e2e is replaced with a condition wait: `expect.poll` on computed styles after viewport resizes, visibility waits for the edit overlay, accordion and Select2 states, a pre-armed `waitForResponse` instead of the deprecated `waitForNavigation`, and the preview-switcher spec disables the wrapper's width transition (not under test) rather than sleeping through it. Along the way, local runs surfaced a real race the slow CI runner had been masking: running `panel/global/open` right after editor load crashes inside Elementor's own `exitPreviewMode()` when the async attach-preview chain hasn't populated `documents.getCurrent().$element` yet — Elementor's source carries TODO comments about this exact sharp edge. `waitForEditor()` now polls for that state directly, which protects every editor test.

Verified locally with the full suite across chromium, firefox and webkit in a single invocation with zero retries, plus repeat-runs on every touched spec. The single-job shape and the concurrency lock get their first real-world validation on this PR's own CI run.

https://claude.ai/code/session_01KGsRfBGPWj5ZJMh9BLLrLa
