### PR TITLE
PHP integration test tiers (wp-env) + fix Elementor-inactive abilities fatal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,12 +253,12 @@ jobs:
       - name: Start wp-env
         run: npm run wp-env start
 
-      - name: Restore dev dependencies for PHPUnit
-        # The production build above ran composer --no-dev, but the integration
-        # suites need phpunit 9.6 + Yoast polyfills. They run in-container via the
-        # dev-vendor mapping (a bind mount of ./vendor), so restoring dev deps on
-        # the host makes them available inside wp-env.
-        run: composer install --prefer-dist --no-progress
+      - name: Install isolated PHPUnit tooling for the integration suites
+        # phpunit 9.6 + Yoast polyfills live in their own Composer project so the
+        # test runner's autoloader can't collide with the plugin's bundled vendor
+        # (same ComposerAutoloaderInit hash => fatal). Mounted into wp-env via the
+        # dev-vendor mapping (tests/php/tools/vendor).
+        run: composer install --prefer-dist --no-progress --working-dir=tests/php/tools
 
       - name: Run PHP integration tests (WordPress + Elementor tiers)
         run: npm run test:php:wp && npm run test:php:elementor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,7 +260,7 @@ jobs:
         # root, mirroring the plugin-check job's stale wp-env cleanup.
         run: |
           docker run --rm -v "$PWD:/w" alpine \
-            sh -c 'rm -rf /w/tests/php/tools/vendor /w/tests/php/dev-vendor' 2>/dev/null || true
+            sh -c 'rm -rf /w/tests/php/tools/vendor' 2>/dev/null || true
 
       - name: Install isolated PHPUnit tooling for the integration suites
         # phpunit 9.6 + Yoast polyfills live in their own Composer project so the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,16 @@ jobs:
       - name: Start wp-env
         run: npm run wp-env start
 
+      - name: Restore dev dependencies for PHPUnit
+        # The production build above ran composer --no-dev, but the integration
+        # suites need phpunit 9.6 + Yoast polyfills. They run in-container via the
+        # dev-vendor mapping (a bind mount of ./vendor), so restoring dev deps on
+        # the host makes them available inside wp-env.
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHP integration tests (WordPress + Elementor tiers)
+        run: npm run test:php:wp && npm run test:php:elementor
+
       - name: Run E2E tests
         # Chromium gates PRs: fast, stable feedback, and one WebKit/Firefox
         # flake can no longer abort the whole gate (maxFailures: 1 is global

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,15 @@ jobs:
       - name: Start wp-env
         run: npm run wp-env start
 
+      - name: Clean stale test-tooling vendor dirs
+        # wp-env's dev-vendor bind mount can leave root-owned dirs under
+        # tests/php from a prior run, which the runner user then can't overwrite
+        # (EACCES on composer install). Remove them from inside a container as
+        # root, mirroring the plugin-check job's stale wp-env cleanup.
+        run: |
+          docker run --rm -v "$PWD:/w" alpine \
+            sh -c 'rm -rf /w/tests/php/tools/vendor /w/tests/php/dev-vendor' 2>/dev/null || true
+
       - name: Install isolated PHPUnit tooling for the integration suites
         # phpunit 9.6 + Yoast polyfills live in their own Composer project so the
         # test runner's autoloader can't collide with the plugin's bundled vendor

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ tasks/
 
 # In-container shadow of ./vendor (wp-env mapping); never exists as a real host dir
 tests/php/dev-vendor/
+
+# Isolated PHPUnit tooling vendor for integration suites
+tests/php/tools/vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ tasks/
 
 # wp-env local override (written by the weekly canary job)
 .wp-env.override.json
+
+# In-container shadow of ./vendor (wp-env mapping); never exists as a real host dir
+tests/php/dev-vendor/

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,7 +8,8 @@
   ],
   "mappings": {
     "wp-content/plugins/fluid-design-system-for-elementor/tests": "./tests",
-    "wp-content/mu-plugins": "./tests/e2e/fixtures/mu-plugins"
+    "wp-content/mu-plugins": "./tests/e2e/fixtures/mu-plugins",
+    "wp-content/plugins/fluid-design-system-for-elementor/tests/php/dev-vendor": "./vendor"
   },
   "config": {
     "WP_DEBUG": true,

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -8,8 +8,7 @@
   ],
   "mappings": {
     "wp-content/plugins/fluid-design-system-for-elementor/tests": "./tests",
-    "wp-content/mu-plugins": "./tests/e2e/fixtures/mu-plugins",
-    "wp-content/plugins/fluid-design-system-for-elementor/tests/php/dev-vendor": "./tests/php/tools/vendor"
+    "wp-content/mu-plugins": "./tests/e2e/fixtures/mu-plugins"
   },
   "config": {
     "WP_DEBUG": true,

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -9,7 +9,7 @@
   "mappings": {
     "wp-content/plugins/fluid-design-system-for-elementor/tests": "./tests",
     "wp-content/mu-plugins": "./tests/e2e/fixtures/mu-plugins",
-    "wp-content/plugins/fluid-design-system-for-elementor/tests/php/dev-vendor": "./vendor"
+    "wp-content/plugins/fluid-design-system-for-elementor/tests/php/dev-vendor": "./tests/php/tools/vendor"
   },
   "config": {
     "WP_DEBUG": true,

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "phpunit/phpunit": "^9.6",
     "squizlabs/php_codesniffer": "^3.13.4",
     "szepeviktor/phpstan-wordpress": "^2.0",
-    "wp-coding-standards/wpcs": "^3.0"
+    "wp-coding-standards/wpcs": "^3.0",
+    "yoast/phpunit-polyfills": "^2.0"
   },
   "minimum-stability": "stable",
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04b586e3c63cca9605fa8025ce0d5122",
+    "content-hash": "950754cbd4a21d3cb7e87492667d99a6",
     "packages": [
         {
             "name": "arts/base",
@@ -7418,6 +7418,69 @@
                 }
             ],
             "time": "2025-11-25T12:08:04+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs",
-    "test:php:wp": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php dev-vendor/bin/phpunit -c phpunit-wp.xml.dist",
-    "test:php:elementor": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php dev-vendor/bin/phpunit -c phpunit-elementor.xml.dist"
+    "test:php:wp": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php tools/vendor/bin/phpunit -c phpunit-wp.xml.dist",
+    "test:php:elementor": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php tools/vendor/bin/phpunit -c phpunit-elementor.xml.dist"
   },
   "lint-staged": {
     "src/ts/**/*.{ts,js,json,css}": "prettier --write",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,9 @@
     "test:e2e:headed": "playwright test --headed",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test:php:wp": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php dev-vendor/bin/phpunit -c phpunit-wp.xml.dist",
+    "test:php:elementor": "wp-env run tests-cli --env-cwd=wp-content/plugins/fluid-design-system-for-elementor/tests/php -- php dev-vendor/bin/phpunit -c phpunit-elementor.xml.dist"
   },
   "lint-staged": {
     "src/ts/**/*.{ts,js,json,css}": "prettier --write",

--- a/src/php/Managers/GroupsData.php
+++ b/src/php/Managers/GroupsData.php
@@ -123,6 +123,14 @@ class GroupsData extends BaseManager {
 	 * @return array<int, array<string, mixed>>
 	 */
 	public static function get_filter_groups(): array {
+		// FluidUnitModule extends an Elementor base class; touching it without
+		// Elementor loaded fatals. Reads that reach here (admin page, fluid/*
+		// abilities) must degrade to "no filter groups", like get_kit_settings
+		// already degrades elsewhere.
+		if ( ! Utilities::is_elementor_plugin_active() ) {
+			return array();
+		}
+
 		$all_groups    = FluidUnitModule::get_all_preset_groups();
 		$builtin_names = self::get_builtin_names();
 
@@ -160,11 +168,16 @@ class GroupsData extends BaseManager {
 	public static function get_builtin_names(): array {
 		$builtin_names = array();
 
-		$default_options = FluidUnitModule::get_default_preset_options();
-		foreach ( $default_options as $option ) {
-			$option_array = Utilities::get_array_value( $option );
-			if ( isset( $option_array['name'] ) ) {
-				$builtin_names[] = Utilities::get_string_value( $option_array['name'] );
+		// The default-option names come from FluidUnitModule (Elementor-gated);
+		// skip them when Elementor is absent. The builtin control mappings below
+		// are pure and always available.
+		if ( Utilities::is_elementor_plugin_active() ) {
+			$default_options = FluidUnitModule::get_default_preset_options();
+			foreach ( $default_options as $option ) {
+				$option_array = Utilities::get_array_value( $option );
+				if ( isset( $option_array['name'] ) ) {
+					$builtin_names[] = Utilities::get_string_value( $option_array['name'] );
+				}
 			}
 		}
 

--- a/src/php/Services/KitRepeaterService.php
+++ b/src/php/Services/KitRepeaterService.php
@@ -225,6 +225,13 @@ class KitRepeaterService {
 	/**
 	 * Recursively applies operation to autosave document.
 	 *
+	 * $kit->get_autosave() (no user id) resolves to the CURRENT user's autosave,
+	 * matching Elementor core's own Kit::add_repeater_row(). A write by user A
+	 * therefore does not mirror into user B's separate open-editor autosave — the
+	 * same acting-user scope the framework uses. This is an intentional match, not
+	 * an oversight; hardening it to enumerate every user's autosave would diverge
+	 * from Elementor and mutate other users' in-progress drafts.
+	 *
 	 * @param \Elementor\Core\Kits\Documents\Kit $kit
 	 * @param string                              $method
 	 * @param mixed                               ...$args

--- a/tests/php/integration/ElementorKitTestCase.php
+++ b/tests/php/integration/ElementorKitTestCase.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Base test case for suites that need Elementor with a real active Kit.
+ *
+ * The plugin activation hook never fires under the test bootstrap (the plugin
+ * is required on muplugins_loaded, not activated), so the default Kit must be
+ * created explicitly — same pattern Elementor's own kit tests use.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration;
+
+use WP_UnitTestCase;
+
+abstract class ElementorKitTestCase extends WP_UnitTestCase {
+
+	/** @var \Elementor\Core\Kits\Documents\Kit */
+	protected $kit;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// Idempotent: no-ops when the elementor_active_kit option is already set.
+		\Elementor\Core\Kits\Manager::create_default_kit();
+
+		$kit = \Elementor\Plugin::$instance->kits_manager->get_active_kit();
+		$this->assertGreaterThan( 0, $kit->get_id(), 'Active Kit was not created' );
+
+		$this->kit = $kit;
+	}
+}

--- a/tests/php/integration/bootstrap-common.php
+++ b/tests/php/integration/bootstrap-common.php
@@ -22,7 +22,7 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
-$_polyfills_dir = dirname( __DIR__ ) . '/dev-vendor/yoast/phpunit-polyfills';
+$_polyfills_dir = dirname( __DIR__ ) . '/tools/vendor/yoast/phpunit-polyfills';
 if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) && file_exists( $_polyfills_dir . '/phpunitpolyfills-autoload.php' ) ) {
 	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_dir );
 }

--- a/tests/php/integration/bootstrap-common.php
+++ b/tests/php/integration/bootstrap-common.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Shared bootstrap for the wp-env integration suites.
+ *
+ * Runs INSIDE the wp-env tests container: WP_TESTS_DIR points at the WordPress
+ * core PHPUnit test library the image ships. That library requires PHPUnit <= 9.6
+ * (the container's global phpunit is 10.x and incompatible), so the suites run
+ * with the plugin's own dev vendor exposed at tests/php/dev-vendor via the
+ * .wp-env.json mapping — that provides both vendor/bin/phpunit 9.6 and the
+ * Yoast polyfills the WP library needs.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/wordpress-phpunit';
+}
+
+if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
+	echo 'WordPress test library not found at ' . $_tests_dir . '. Run inside the wp-env tests container.' . PHP_EOL;
+	exit( 1 );
+}
+
+$_polyfills_dir = dirname( __DIR__ ) . '/dev-vendor/yoast/phpunit-polyfills';
+if ( ! defined( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' ) && file_exists( $_polyfills_dir . '/phpunitpolyfills-autoload.php' ) ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_polyfills_dir );
+}
+
+require_once $_tests_dir . '/includes/functions.php';

--- a/tests/php/integration/bootstrap-elementor.php
+++ b/tests/php/integration/bootstrap-elementor.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Bootstrap for the Elementor integration suite (real Kit available).
+ *
+ * Elementor is required before the plugin, mirroring normal load order. The
+ * activation hook never fires under the test bootstrap, so no default Kit
+ * exists — ElementorKitTestCase::set_up() creates it per test.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+require __DIR__ . '/bootstrap-common.php';
+
+tests_add_filter(
+	'muplugins_loaded',
+	function () {
+		$plugins_dir = dirname( __DIR__, 4 );
+
+		// wp-env installs the zip under elementor.latest-stable; plain elementor is the fallback.
+		foreach ( array( 'elementor.latest-stable', 'elementor' ) as $dir ) {
+			if ( file_exists( $plugins_dir . '/' . $dir . '/elementor.php' ) ) {
+				require $plugins_dir . '/' . $dir . '/elementor.php';
+				break;
+			}
+		}
+
+		require dirname( __DIR__, 3 ) . '/fluid-design-system-for-elementor.php';
+	}
+);
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/wordpress-phpunit';
+}
+require $_tests_dir . '/includes/bootstrap.php';
+
+// Shared test-case classes are not test files, so PHPUnit's directory scan
+// never includes them; the dev-vendor autoloader maps host paths that don't
+// exist in the container. Require them directly, like Elementor's bootstrap does.
+require_once __DIR__ . '/ElementorKitTestCase.php';

--- a/tests/php/integration/bootstrap-wp.php
+++ b/tests/php/integration/bootstrap-wp.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Bootstrap for the WordPress-only integration suite (no Elementor loaded).
+ *
+ * Loading only the plugin keeps GroupsData's no-Elementor fallback reachable —
+ * that degradation path is part of what this suite asserts.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+require __DIR__ . '/bootstrap-common.php';
+
+tests_add_filter(
+	'muplugins_loaded',
+	function () {
+		// tests/php/integration -> plugin root (the mapped tests dir lives inside the dist-mounted plugin).
+		require dirname( __DIR__, 3 ) . '/fluid-design-system-for-elementor.php';
+	}
+);
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/wordpress-phpunit';
+}
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/php/integration/elementor/AbilitiesPresetCallbacksTest.php
+++ b/tests/php/integration/elementor/AbilitiesPresetCallbacksTest.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Integration tests for the preset-scoped ability execute callbacks.
+ *
+ * These need a real active Kit: they resolve group ids to Kit controls and
+ * route through KitRepeaterService / Kit::add_repeater_row.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\Elementor;
+
+use Arts\FluidDesignSystem\Base\ManagersContainer;
+use Arts\FluidDesignSystem\Managers\Abilities;
+use Arts\FluidDesignSystem\Managers\Data;
+use Arts\FluidDesignSystem\Services\KitRepeaterService;
+use Arts\FluidDesignSystem\Tests\Integration\ElementorKitTestCase;
+
+class AbilitiesPresetCallbacksTest extends ElementorKitTestCase {
+
+	private function abilities(): Abilities {
+		$abilities       = new Abilities();
+		$container       = new ManagersContainer();
+		$container->data = new Data();
+		$abilities->init( $container );
+
+		return $abilities;
+	}
+
+	/** @return array<string, mixed> */
+	private function create_preset( Abilities $abilities, string $title, string $group = 'fluid_spacing_presets' ): array {
+		$result = $abilities->execute_create_preset(
+			array(
+				'title'    => $title,
+				'min_size' => 10,
+				'min_unit' => 'px',
+				'max_size' => 40,
+				'max_unit' => 'px',
+				'group_id' => $group,
+			)
+		);
+
+		$this->assertIsArray( $result, 'create-preset returned an error: ' . ( is_wp_error( $result ) ? $result->get_error_message() : '' ) );
+
+		return $result['preset'];
+	}
+
+	public function test_create_preset_persists_to_kit(): void {
+		$abilities = $this->abilities();
+		$preset    = $this->create_preset( $abilities, 'Ability Preset' );
+
+		$this->assertStringStartsWith( 'fluid-', $preset['id'] );
+		$this->assertSame( 'Ability Preset', $preset['title'] );
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', $preset['id'] );
+		$this->assertSame( 'Ability Preset', $item['title'] );
+		$this->assertSame( 10.0, $item['min']['size'] );
+	}
+
+	public function test_get_preset_errors_for_missing_id(): void {
+		$missing = $this->abilities()->execute_get_preset(
+			array(
+				'preset_id' => 'fluid-does-not-exist',
+				'group_id'  => 'fluid_spacing_presets',
+			)
+		);
+
+		$this->assertWPError( $missing );
+		$this->assertSame( 'preset_not_found', $missing->get_error_code() );
+	}
+
+	public function test_update_preset_renames(): void {
+		$abilities = $this->abilities();
+		$preset    = $this->create_preset( $abilities, 'Old Name' );
+
+		$updated = $abilities->execute_update_preset(
+			array(
+				'preset_id' => $preset['id'],
+				'group_id'  => 'fluid_spacing_presets',
+				'title'     => 'New Name',
+			)
+		);
+
+		$this->assertIsArray( $updated );
+		$this->assertSame( 'New Name', $updated['preset']['title'] );
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', $preset['id'] );
+		$this->assertSame( 'New Name', $item['title'] );
+	}
+
+	public function test_move_preset_to_group(): void {
+		$abilities = $this->abilities();
+		$preset    = $this->create_preset( $abilities, 'Wanderer' );
+
+		$moved = $abilities->execute_move_preset_to_group(
+			array(
+				'preset_id'     => $preset['id'],
+				'from_group_id' => 'fluid_spacing_presets',
+				'to_group_id'   => 'fluid_typography_presets',
+			)
+		);
+
+		$this->assertIsArray( $moved );
+		$this->assertTrue( $moved['moved'] );
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_typography_presets', $preset['id'] );
+		$this->assertSame( 'Wanderer', $item['title'] );
+	}
+
+	public function test_move_preset_rejects_same_group(): void {
+		$abilities = $this->abilities();
+		$preset    = $this->create_preset( $abilities, 'Stayer' );
+
+		$error = $abilities->execute_move_preset_to_group(
+			array(
+				'preset_id'     => $preset['id'],
+				'from_group_id' => 'fluid_spacing_presets',
+				'to_group_id'   => 'fluid_spacing_presets',
+			)
+		);
+
+		$this->assertWPError( $error );
+		$this->assertSame( 'same_group', $error->get_error_code() );
+	}
+
+	public function test_delete_preset(): void {
+		$abilities = $this->abilities();
+		$preset    = $this->create_preset( $abilities, 'Short Lived' );
+
+		$deleted = $abilities->execute_delete_preset(
+			array(
+				'preset_id' => $preset['id'],
+				'group_id'  => 'fluid_spacing_presets',
+			)
+		);
+
+		$this->assertIsArray( $deleted );
+		$this->assertTrue( $deleted['deleted'] );
+
+		$again = $abilities->execute_delete_preset(
+			array(
+				'preset_id' => $preset['id'],
+				'group_id'  => 'fluid_spacing_presets',
+			)
+		);
+		$this->assertWPError( $again );
+		$this->assertSame( 'delete_failed', $again->get_error_code() );
+	}
+}

--- a/tests/php/integration/elementor/ControlRegistryKitTest.php
+++ b/tests/php/integration/elementor/ControlRegistryKitTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Integration tests for ControlRegistry's Kit-backed resolution.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\Elementor;
+
+use Arts\FluidDesignSystem\Managers\ControlRegistry;
+use Arts\FluidDesignSystem\Tests\Integration\ElementorKitTestCase;
+
+class ControlRegistryKitTest extends ElementorKitTestCase {
+
+	public function test_builtin_control_id_passes_through(): void {
+		$this->assertSame( 'fluid_spacing_presets', ControlRegistry::get_kit_control_id( 'fluid_spacing_presets' ) );
+	}
+
+	public function test_custom_group_resolves_against_kit_settings(): void {
+		$this->kit->add_repeater_row(
+			'fluid_custom_resolver_presets',
+			array(
+				'_id'   => 'r1',
+				'title' => 'Resolver',
+			)
+		);
+
+		$this->assertSame( 'fluid_custom_resolver_presets', ControlRegistry::get_kit_control_id( 'resolver' ) );
+		$this->assertSame( 'fluid_custom_resolver_presets', ControlRegistry::get_kit_control_id( 'fluid_custom_resolver_presets' ) );
+	}
+
+	public function test_unknown_group_returns_false(): void {
+		$this->assertFalse( ControlRegistry::get_kit_control_id( 'never_created' ) );
+	}
+}

--- a/tests/php/integration/elementor/KitCssTest.php
+++ b/tests/php/integration/elementor/KitCssTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Integration test for the rendered Kit CSS: a seeded preset must emit its
+ * --arts-fluid-preset-- variable with a clamp() formula.
+ *
+ * Post_CSS instances are memoized per request and get_content() self-caches,
+ * so the file is deleted and rebuilt explicitly.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\Elementor;
+
+use Arts\FluidDesignSystem\Tests\Integration\ElementorKitTestCase;
+use Elementor\Core\Files\CSS\Post as Post_CSS;
+
+class KitCssTest extends ElementorKitTestCase {
+
+	public function test_kit_css_contains_preset_variable_with_clamp(): void {
+		$this->kit->add_repeater_row(
+			'fluid_spacing_presets',
+			array(
+				'_id'   => 'css_smoke',
+				'title' => 'CSS Smoke',
+				'min'   => array(
+					'size' => 16,
+					'unit' => 'px',
+				),
+				'max'   => array(
+					'size' => 48,
+					'unit' => 'px',
+				),
+			)
+		);
+
+		$css_file = Post_CSS::create( $this->kit->get_id() );
+		$css_file->delete();
+		$css_file->update();
+		$content = $css_file->get_content();
+
+		$this->assertStringContainsString( '--arts-fluid-preset--css_smoke', $content );
+		$this->assertStringContainsString( 'clamp(', $content );
+	}
+}

--- a/tests/php/integration/elementor/KitRepeaterServiceTest.php
+++ b/tests/php/integration/elementor/KitRepeaterServiceTest.php
@@ -2,9 +2,9 @@
 /**
  * Integration tests for KitRepeaterService against a real Elementor Kit.
  *
- * Harness smoke scope: seed a repeater row through the supported Kit API and
- * read it back through the service. The full CRUD + autosave-mirroring
- * inventory builds on this once the wiring is proven.
+ * Covers the CRUD surface and the invariant the service exists for: every
+ * write must mirror to the Kit's autosave document, because the editor reads
+ * settings through get_doc_or_auto_save and would otherwise show stale data.
  *
  * @package Arts\FluidDesignSystem\Tests
  */
@@ -16,26 +16,137 @@ use Arts\FluidDesignSystem\Tests\Integration\ElementorKitTestCase;
 
 class KitRepeaterServiceTest extends ElementorKitTestCase {
 
-	public function test_get_item_returns_row_seeded_via_kit_api(): void {
+	/** @param array<string, mixed> $extra */
+	private function seed_preset( string $id, string $title, array $extra = array(), string $control_id = 'fluid_spacing_presets' ): void {
 		$this->kit->add_repeater_row(
-			'fluid_spacing_presets',
-			array(
-				'_id'   => 'smoke_preset',
-				'title' => 'Smoke Preset',
-				'min'   => array(
-					'size' => 16,
-					'unit' => 'px',
+			$control_id,
+			array_merge(
+				array(
+					'_id'   => $id,
+					'title' => $title,
+					'min'   => array(
+						'size' => 16,
+						'unit' => 'px',
+					),
+					'max'   => array(
+						'size' => 48,
+						'unit' => 'px',
+					),
 				),
-				'max'   => array(
-					'size' => 48,
-					'unit' => 'px',
-				),
+				$extra
 			)
 		);
+	}
+
+	public function test_get_item_returns_row_seeded_via_kit_api(): void {
+		$this->seed_preset( 'smoke_preset', 'Smoke Preset' );
 
 		$item = KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', 'smoke_preset' );
 
 		$this->assertIsArray( $item );
 		$this->assertSame( 'Smoke Preset', $item['title'] );
+	}
+
+	public function test_get_item_throws_for_missing_preset_and_group(): void {
+		$this->seed_preset( 'existing', 'Existing' );
+
+		try {
+			KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', 'ghost' );
+			$this->fail( 'Expected exception for missing preset' );
+		} catch ( \Exception $e ) {
+			$this->assertSame( 'Preset not found.', $e->getMessage() );
+		}
+
+		try {
+			KitRepeaterService::get_item( $this->kit, 'fluid_custom_ghost_presets', 'existing' );
+			$this->fail( 'Expected exception for missing group' );
+		} catch ( \Exception $e ) {
+			$this->assertSame( 'Preset group not found.', $e->getMessage() );
+		}
+	}
+
+	public function test_update_item_merges_and_preserves_untouched_fields(): void {
+		$this->seed_preset(
+			'merge_preset',
+			'Original Title',
+			array( 'custom_screen_width' => 'yes' )
+		);
+
+		$this->assertTrue(
+			KitRepeaterService::update_item(
+				$this->kit,
+				'fluid_spacing_presets',
+				'merge_preset',
+				array( 'title' => 'Updated Title' )
+			)
+		);
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', 'merge_preset' );
+		$this->assertSame( 'Updated Title', $item['title'] );
+		$this->assertSame( 'yes', $item['custom_screen_width'] );
+		$this->assertSame( 16, $item['min']['size'] );
+	}
+
+	public function test_delete_item_removes_row(): void {
+		$this->seed_preset( 'doomed', 'Doomed' );
+
+		$this->assertTrue( KitRepeaterService::delete_item( $this->kit, 'fluid_spacing_presets', 'doomed' ) );
+
+		$this->expectExceptionMessage( 'Preset not found.' );
+		KitRepeaterService::delete_item( $this->kit, 'fluid_spacing_presets', 'doomed' );
+	}
+
+	public function test_move_item_between_controls(): void {
+		$this->seed_preset( 'mover', 'Mover' );
+
+		$this->assertTrue(
+			KitRepeaterService::move_item( $this->kit, 'fluid_spacing_presets', 'fluid_typography_presets', 'mover' )
+		);
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_typography_presets', 'mover' );
+		$this->assertSame( 'Mover', $item['title'] );
+
+		$this->expectExceptionMessage( 'Preset not found.' );
+		KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', 'mover' );
+	}
+
+	public function test_move_item_initializes_missing_target_control(): void {
+		$this->seed_preset( 'pioneer', 'Pioneer' );
+
+		$this->assertTrue(
+			KitRepeaterService::move_item( $this->kit, 'fluid_spacing_presets', 'fluid_custom_newgroup_presets', 'pioneer' )
+		);
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_custom_newgroup_presets', 'pioneer' );
+		$this->assertSame( 'Pioneer', $item['title'] );
+	}
+
+	/**
+	 * The stale-editor guard: with an autosave present, a write to the main
+	 * Kit must recursively apply to the autosave document too.
+	 */
+	public function test_writes_mirror_to_autosave(): void {
+		$this->seed_preset( 'mirrored', 'Before Mirror' );
+
+		$autosave = $this->kit->get_autosave( get_current_user_id(), true );
+		$this->assertInstanceOf(
+			\Elementor\Core\Kits\Documents\Kit::class,
+			$autosave,
+			'Kit autosave must be a Kit document or process_autosave() silently skips mirroring'
+		);
+
+		KitRepeaterService::update_item(
+			$this->kit,
+			'fluid_spacing_presets',
+			'mirrored',
+			array( 'title' => 'After Mirror' )
+		);
+
+		$autosave_item = KitRepeaterService::get_item(
+			$this->kit->get_autosave(),
+			'fluid_spacing_presets',
+			'mirrored'
+		);
+		$this->assertSame( 'After Mirror', $autosave_item['title'] );
 	}
 }

--- a/tests/php/integration/elementor/KitRepeaterServiceTest.php
+++ b/tests/php/integration/elementor/KitRepeaterServiceTest.php
@@ -128,6 +128,22 @@ class KitRepeaterServiceTest extends ElementorKitTestCase {
 	public function test_writes_mirror_to_autosave(): void {
 		$this->seed_preset( 'mirrored', 'Before Mirror' );
 
+		// Backdate the Kit post so the autosave created below is strictly newer:
+		// Elementor's autosave lookup (Utils::get_post_autosave) requires
+		// post_modified_gmt > the parent's, which same-second creation in a fast
+		// test would otherwise fail, making get_autosave() return false.
+		global $wpdb;
+		$past = gmdate( 'Y-m-d H:i:s', time() - 60 );
+		$wpdb->update(
+			$wpdb->posts,
+			array(
+				'post_modified'     => $past,
+				'post_modified_gmt' => $past,
+			),
+			array( 'ID' => $this->kit->get_id() )
+		);
+		clean_post_cache( $this->kit->get_id() );
+
 		$autosave = $this->kit->get_autosave( get_current_user_id(), true );
 		$this->assertInstanceOf(
 			\Elementor\Core\Kits\Documents\Kit::class,

--- a/tests/php/integration/elementor/KitRepeaterServiceTest.php
+++ b/tests/php/integration/elementor/KitRepeaterServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Integration tests for KitRepeaterService against a real Elementor Kit.
+ *
+ * Harness smoke scope: seed a repeater row through the supported Kit API and
+ * read it back through the service. The full CRUD + autosave-mirroring
+ * inventory builds on this once the wiring is proven.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\Elementor;
+
+use Arts\FluidDesignSystem\Services\KitRepeaterService;
+use Arts\FluidDesignSystem\Tests\Integration\ElementorKitTestCase;
+
+class KitRepeaterServiceTest extends ElementorKitTestCase {
+
+	public function test_get_item_returns_row_seeded_via_kit_api(): void {
+		$this->kit->add_repeater_row(
+			'fluid_spacing_presets',
+			array(
+				'_id'   => 'smoke_preset',
+				'title' => 'Smoke Preset',
+				'min'   => array(
+					'size' => 16,
+					'unit' => 'px',
+				),
+				'max'   => array(
+					'size' => 48,
+					'unit' => 'px',
+				),
+			)
+		);
+
+		$item = KitRepeaterService::get_item( $this->kit, 'fluid_spacing_presets', 'smoke_preset' );
+
+		$this->assertIsArray( $item );
+		$this->assertSame( 'Smoke Preset', $item['title'] );
+	}
+}

--- a/tests/php/integration/wp/AbilitiesGatesTest.php
+++ b/tests/php/integration/wp/AbilitiesGatesTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Integration tests for the Abilities permission gates.
+ *
+ * The frozen contract: fluid/* reads gate on edit_posts, writes on
+ * manage_options. Direct calls to the public permission callbacks under real
+ * WP roles — no Abilities API plugin required.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\WP;
+
+use Arts\FluidDesignSystem\Managers\Abilities;
+use WP_UnitTestCase;
+
+class AbilitiesGatesTest extends WP_UnitTestCase {
+
+	private function abilities(): Abilities {
+		return new Abilities();
+	}
+
+	public function test_subscriber_can_neither_read_nor_manage(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+
+		$this->assertFalse( $this->abilities()->can_read() );
+		$this->assertFalse( $this->abilities()->can_manage() );
+	}
+
+	public function test_editor_can_read_but_not_manage(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$this->assertTrue( $this->abilities()->can_read() );
+		$this->assertFalse( $this->abilities()->can_manage() );
+	}
+
+	public function test_administrator_can_read_and_manage(): void {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertTrue( $this->abilities()->can_read() );
+		$this->assertTrue( $this->abilities()->can_manage() );
+	}
+
+	public function test_logged_out_visitor_is_denied(): void {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $this->abilities()->can_read() );
+		$this->assertFalse( $this->abilities()->can_manage() );
+	}
+}

--- a/tests/php/integration/wp/AbilitiesGroupCallbacksTest.php
+++ b/tests/php/integration/wp/AbilitiesGroupCallbacksTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Integration tests for the group-scoped ability execute callbacks.
+ *
+ * Callbacks are invoked directly (no wp_register_ability needed — the
+ * Abilities API plugin is absent here by design). The managers container is
+ * wired the same way the plugin bootstrap does it.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\WP;
+
+use Arts\FluidDesignSystem\Base\ManagersContainer;
+use Arts\FluidDesignSystem\Managers\Abilities;
+use Arts\FluidDesignSystem\Managers\Data;
+use WP_UnitTestCase;
+
+class AbilitiesGroupCallbacksTest extends WP_UnitTestCase {
+
+	private function abilities(): Abilities {
+		$abilities       = new Abilities();
+		$container       = new ManagersContainer();
+		$container->data = new Data();
+		$abilities->init( $container );
+
+		return $abilities;
+	}
+
+	public function test_list_preset_groups_includes_builtins(): void {
+		$result = $this->abilities()->execute_list_preset_groups();
+
+		$this->assertIsArray( $result );
+		$names = array_column( $result['groups'], 'name' );
+		$this->assertContains( 'Spacing Presets', $names );
+		$this->assertContains( 'Typography Presets', $names );
+	}
+
+	public function test_create_preset_group_persists_and_reports(): void {
+		$result = $this->abilities()->execute_create_preset_group(
+			array(
+				'name'        => 'Ability Group',
+				'description' => 'Made via ability callback',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$group = $result['group'];
+		$this->assertSame( 'Ability Group', $group['name'] );
+		$this->assertSame( 'custom', $group['type'] );
+		$this->assertSame( 'fluid_custom_' . $group['id'] . '_presets', $group['control_id'] );
+
+		$this->assertTrue( ( new Data() )->group_exists( $group['id'] ) );
+	}
+
+	public function test_create_preset_group_rejects_taken_name(): void {
+		$abilities = $this->abilities();
+		$abilities->execute_create_preset_group( array( 'name' => 'Occupied' ) );
+
+		$error = $abilities->execute_create_preset_group( array( 'name' => 'Occupied' ) );
+		$this->assertWPError( $error );
+		$this->assertSame( 'name_taken', $error->get_error_code() );
+
+		$builtin_collision = $abilities->execute_create_preset_group( array( 'name' => 'Spacing Presets' ) );
+		$this->assertWPError( $builtin_collision );
+		$this->assertSame( 'name_taken', $builtin_collision->get_error_code() );
+	}
+
+	public function test_rename_preset_group(): void {
+		$abilities = $this->abilities();
+		$created   = $abilities->execute_create_preset_group( array( 'name' => 'Before Rename' ) );
+		$group_id  = $created['group']['id'];
+
+		$renamed = $abilities->execute_rename_preset_group(
+			array(
+				'group_id' => $group_id,
+				'name'     => 'After Rename',
+			)
+		);
+		$this->assertIsArray( $renamed );
+		$this->assertSame( 'After Rename', $renamed['group']['name'] );
+		$this->assertSame( 'After Rename', ( new Data() )->get_group( $group_id )['name'] );
+
+		$missing = $abilities->execute_rename_preset_group(
+			array(
+				'group_id' => 'nope',
+				'name'     => 'Whatever',
+			)
+		);
+		$this->assertWPError( $missing );
+		$this->assertSame( 'group_not_found', $missing->get_error_code() );
+	}
+
+	public function test_rename_preset_group_rejects_collision(): void {
+		$abilities = $this->abilities();
+		$abilities->execute_create_preset_group( array( 'name' => 'Existing Name' ) );
+		$created = $abilities->execute_create_preset_group( array( 'name' => 'To Rename' ) );
+
+		$collision = $abilities->execute_rename_preset_group(
+			array(
+				'group_id' => $created['group']['id'],
+				'name'     => 'Existing Name',
+			)
+		);
+		$this->assertWPError( $collision );
+		$this->assertSame( 'name_taken', $collision->get_error_code() );
+	}
+
+	public function test_delete_preset_group(): void {
+		$abilities = $this->abilities();
+		$created   = $abilities->execute_create_preset_group( array( 'name' => 'Delete Me' ) );
+		$group_id  = $created['group']['id'];
+
+		$deleted = $abilities->execute_delete_preset_group( array( 'group_id' => $group_id ) );
+		$this->assertIsArray( $deleted );
+		$this->assertTrue( $deleted['deleted'] );
+		$this->assertFalse( ( new Data() )->group_exists( $group_id ) );
+
+		$missing = $abilities->execute_delete_preset_group( array( 'group_id' => $group_id ) );
+		$this->assertWPError( $missing );
+		$this->assertSame( 'group_not_found', $missing->get_error_code() );
+	}
+
+	public function test_get_preset_group_returns_group_with_empty_presets_without_elementor(): void {
+		$result = $this->abilities()->execute_get_preset_group( array( 'group_id' => 'fluid_spacing_presets' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Spacing Presets', $result['group']['name'] );
+		$this->assertSame( array(), $result['presets'] );
+
+		$missing = $this->abilities()->execute_get_preset_group( array( 'group_id' => 'no_such_group' ) );
+		$this->assertWPError( $missing );
+		$this->assertSame( 'group_not_found', $missing->get_error_code() );
+	}
+}

--- a/tests/php/integration/wp/DataTest.php
+++ b/tests/php/integration/wp/DataTest.php
@@ -39,4 +39,68 @@ class DataTest extends WP_UnitTestCase {
 		$this->assertIsString( $first );
 		$this->assertFalse( $data->create_group( 'Unique Group' ) );
 	}
+
+	public function test_order_increments_per_created_group(): void {
+		$data = new Data();
+
+		$first  = $data->create_group( 'First' );
+		$second = $data->create_group( 'Second' );
+
+		$this->assertSame( 1, $data->get_group( $first )['order'] );
+		$this->assertSame( 2, $data->get_group( $second )['order'] );
+	}
+
+	public function test_delete_group(): void {
+		$data = new Data();
+
+		$group_id = $data->create_group( 'Doomed' );
+		$this->assertIsString( $group_id );
+
+		$this->assertTrue( $data->delete_group( $group_id ) );
+		$this->assertFalse( $data->group_exists( $group_id ) );
+		$this->assertNull( $data->get_group( $group_id ) );
+
+		$this->assertFalse( $data->delete_group( $group_id ) );
+	}
+
+	public function test_name_exists_respects_exclude_id(): void {
+		$data = new Data();
+
+		$group_id = $data->create_group( 'Named Group' );
+
+		$this->assertTrue( Data::name_exists( 'Named Group' ) );
+		$this->assertFalse( Data::name_exists( 'Named Group', $group_id ) );
+		$this->assertFalse( Data::name_exists( 'Other Name' ) );
+	}
+
+	public function test_reorder_groups_updates_order_fields(): void {
+		$data = new Data();
+
+		$a = $data->create_group( 'Alpha' );
+		$b = $data->create_group( 'Beta' );
+
+		$this->assertTrue( $data->reorder_groups( array( $b, $a ) ) );
+		$this->assertSame( 1, $data->get_group( $b )['order'] );
+		$this->assertSame( 2, $data->get_group( $a )['order'] );
+	}
+
+	public function test_reorder_groups_rejects_unknown_id(): void {
+		$data = new Data();
+
+		$a = $data->create_group( 'Alpha' );
+
+		$this->assertFalse( $data->reorder_groups( array( $a, 'nonexistent_id' ) ) );
+	}
+
+	public function test_main_group_order_roundtrip(): void {
+		$this->assertFalse( Data::is_main_group_ordering_active() );
+
+		Data::save_main_group_order( array( 'fluid_typography_presets', 'fluid_spacing_presets' ) );
+
+		$this->assertTrue( Data::is_main_group_ordering_active() );
+		$this->assertSame(
+			array( 'fluid_typography_presets', 'fluid_spacing_presets' ),
+			Data::get_main_group_order()
+		);
+	}
 }

--- a/tests/php/integration/wp/DataTest.php
+++ b/tests/php/integration/wp/DataTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Integration tests for the Data manager (custom-group CRUD over WP options).
+ *
+ * Runs against real WordPress: sanitize_key/sanitize_text_field semantics and
+ * option persistence are the point, so nothing is stubbed.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\WP;
+
+use Arts\FluidDesignSystem\Managers\Data;
+use WP_UnitTestCase;
+
+class DataTest extends WP_UnitTestCase {
+
+	public function test_create_and_get_group(): void {
+		$data = new Data();
+
+		$group_id = $data->create_group( 'Smoke Group', 'Created by the wp-env harness smoke test' );
+
+		$this->assertIsString( $group_id );
+		// sanitize_key strips characters outside [a-z0-9_-]; spaces are removed, not underscored.
+		$this->assertStringStartsWith( 'smokegroup_', $group_id );
+		$this->assertTrue( $data->group_exists( $group_id ) );
+
+		$group = $data->get_group( $group_id );
+		$this->assertIsArray( $group );
+		$this->assertSame( 'Smoke Group', $group['name'] );
+		$this->assertSame( 'Created by the wp-env harness smoke test', $group['description'] );
+		$this->assertSame( 1, $group['order'] );
+	}
+
+	public function test_create_group_rejects_duplicate_name(): void {
+		$data = new Data();
+
+		$first = $data->create_group( 'Unique Group' );
+		$this->assertIsString( $first );
+		$this->assertFalse( $data->create_group( 'Unique Group' ) );
+	}
+}

--- a/tests/php/integration/wp/GroupsDataTest.php
+++ b/tests/php/integration/wp/GroupsDataTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Integration tests for GroupsData aggregation.
+ *
+ * This suite runs WITHOUT Elementor on purpose: preset values degrade to
+ * empty arrays (Utilities::get_kit_settings fallback) while merge, ordering
+ * and name-collision logic stay fully exercisable.
+ *
+ * @package Arts\FluidDesignSystem\Tests
+ */
+
+namespace Arts\FluidDesignSystem\Tests\Integration\WP;
+
+use Arts\FluidDesignSystem\Managers\Data;
+use Arts\FluidDesignSystem\Managers\GroupsData;
+use WP_UnitTestCase;
+
+class GroupsDataTest extends WP_UnitTestCase {
+
+	public function test_builtin_groups_present_and_degrade_without_elementor(): void {
+		$builtin = GroupsData::get_builtin_groups();
+
+		$this->assertCount( 2, $builtin );
+		$this->assertSame( 'Spacing Presets', $builtin[0]['name'] );
+		$this->assertSame( 'Typography Presets', $builtin[1]['name'] );
+		$this->assertSame( 'builtin', $builtin[0]['type'] );
+		$this->assertSame( 'fluid_spacing_presets', $builtin[0]['id'] );
+		// No Elementor loaded: kit settings fall back to the provided default.
+		$this->assertSame( array(), $builtin[0]['value'] );
+	}
+
+	public function test_custom_group_appears_in_all_groups(): void {
+		$data     = new Data();
+		$group_id = $data->create_group( 'Aggregated Group' );
+
+		$names = array_column( GroupsData::get_all_groups(), 'name' );
+
+		$this->assertContains( 'Aggregated Group', $names );
+
+		$custom = GroupsData::get_custom_groups();
+		$this->assertSame( 'custom', $custom[0]['type'] );
+		$this->assertSame( $group_id, $custom[0]['id'] );
+	}
+
+	public function test_filter_injected_group_is_typed_and_collision_checked(): void {
+		add_filter(
+			'arts/fluid_design_system/custom_presets',
+			function ( $groups ) {
+				$groups[] = array(
+					'name'  => 'Dev Filter Group',
+					'value' => array(),
+				);
+				return $groups;
+			}
+		);
+
+		$filter_groups = GroupsData::get_filter_groups();
+		$names         = array_column( $filter_groups, 'name' );
+
+		$this->assertContains( 'Dev Filter Group', $names );
+		$this->assertSame( 'filter', $filter_groups[ array_search( 'Dev Filter Group', $names, true ) ]['type'] );
+
+		$this->assertTrue( GroupsData::is_group_name_taken( 'Dev Filter Group' ) );
+	}
+
+	public function test_name_collision_across_builtin_and_custom(): void {
+		$this->assertTrue( GroupsData::is_group_name_taken( 'Spacing Presets' ) );
+
+		$data = new Data();
+		$data->create_group( 'Taken Custom Name' );
+		$this->assertTrue( GroupsData::is_group_name_taken( 'Taken Custom Name' ) );
+
+		$this->assertFalse( GroupsData::is_group_name_taken( 'Free Name' ) );
+	}
+
+	public function test_main_group_order_is_applied(): void {
+		$defaults = GroupsData::get_main_groups();
+		$this->assertSame( 'fluid_spacing_presets', $defaults[0]['id'] );
+
+		Data::save_main_group_order( array( 'fluid_typography_presets', 'fluid_spacing_presets' ) );
+
+		$ordered = GroupsData::get_main_groups();
+		$this->assertSame( 'fluid_typography_presets', $ordered[0]['id'] );
+		$this->assertSame( 'fluid_spacing_presets', $ordered[1]['id'] );
+	}
+}

--- a/tests/php/integration/wp/GroupsDataTest.php
+++ b/tests/php/integration/wp/GroupsDataTest.php
@@ -42,7 +42,13 @@ class GroupsDataTest extends WP_UnitTestCase {
 		$this->assertSame( $group_id, $custom[0]['id'] );
 	}
 
-	public function test_filter_injected_group_is_typed_and_collision_checked(): void {
+	/**
+	 * Filter groups come from FluidUnitModule, which is Elementor-gated, so
+	 * without Elementor loaded they must degrade to empty rather than fatal —
+	 * even when a filter is registered. (The populated path is covered by the
+	 * Elementor tier and by e2e.)
+	 */
+	public function test_filter_groups_degrade_without_elementor(): void {
 		add_filter(
 			'arts/fluid_design_system/custom_presets',
 			function ( $groups ) {
@@ -54,13 +60,8 @@ class GroupsDataTest extends WP_UnitTestCase {
 			}
 		);
 
-		$filter_groups = GroupsData::get_filter_groups();
-		$names         = array_column( $filter_groups, 'name' );
-
-		$this->assertContains( 'Dev Filter Group', $names );
-		$this->assertSame( 'filter', $filter_groups[ array_search( 'Dev Filter Group', $names, true ) ]['type'] );
-
-		$this->assertTrue( GroupsData::is_group_name_taken( 'Dev Filter Group' ) );
+		$this->assertSame( array(), GroupsData::get_filter_groups() );
+		$this->assertFalse( GroupsData::is_group_name_taken( 'Dev Filter Group' ) );
 	}
 
 	public function test_name_collision_across_builtin_and_custom(): void {

--- a/tests/php/phpunit-elementor.xml.dist
+++ b/tests/php/phpunit-elementor.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	bootstrap="integration/bootstrap-elementor.php"
+	colors="true"
+>
+	<testsuites>
+		<testsuite name="elementor">
+			<directory>integration/elementor</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/php/phpunit-wp.xml.dist
+++ b/tests/php/phpunit-wp.xml.dist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+	bootstrap="integration/bootstrap-wp.php"
+	colors="true"
+>
+	<testsuites>
+		<testsuite name="wp">
+			<directory>integration/wp</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/php/tools/composer.json
+++ b/tests/php/tools/composer.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://getcomposer.org/schema.json",
-  "description": "Isolated PHPUnit + polyfills for the wp-env integration suites. Kept as a separate Composer project so its autoloader hash differs from the plugin's bundled vendor — mounting the plugin's own vendor as the test runner collides on ComposerAutoloaderInit and fatals.",
+  "description": "Isolated PHPUnit + polyfills for the wp-env integration suites. Kept as a separate Composer project so its autoloader hash differs from the plugin's bundled vendor \u2014 mounting the plugin's own vendor as the test runner collides on ComposerAutoloaderInit and fatals.",
   "require": {
     "phpunit/phpunit": "^9.6",
     "yoast/phpunit-polyfills": "^2.0"
   },
   "config": {
-    "optimize-autoloader": true
+    "optimize-autoloader": true,
+    "platform": {
+      "php": "8.0"
+    }
   }
 }

--- a/tests/php/tools/composer.json
+++ b/tests/php/tools/composer.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://getcomposer.org/schema.json",
+  "description": "Isolated PHPUnit + polyfills for the wp-env integration suites. Kept as a separate Composer project so its autoloader hash differs from the plugin's bundled vendor — mounting the plugin's own vendor as the test runner collides on ComposerAutoloaderInit and fatals.",
+  "require": {
+    "phpunit/phpunit": "^9.6",
+    "yoast/phpunit-polyfills": "^2.0"
+  },
+  "config": {
+    "optimize-autoloader": true
+  }
+}

--- a/tests/php/tools/composer.lock
+++ b/tests/php/tools/composer.lock
@@ -1,0 +1,1877 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "c1e569eaefe32c7cfa446c3acd53f29f",
+    "packages": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/tests/php/tools/composer.lock
+++ b/tests/php/tools/composer.lock
@@ -4,33 +4,34 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1e569eaefe32c7cfa446c3acd53f29f",
+    "content-hash": "8134ce7ec38f2f393669f1b18fa09586",
     "packages": [
         {
             "name": "doctrine/instantiator",
-            "version": "2.1.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
-                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.4"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^14",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1",
-                "phpstan/phpstan-phpunit": "^2.0",
-                "phpunit/phpunit": "^10.5.58"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -57,7 +58,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -73,7 +74,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T06:47:08+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1873,5 +1874,8 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.0"
+    },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
The second half of the PHP test layer, building on the pure-unit tier (#43): wp-env PHPUnit integration suites, plus a bug they surfaced.

## The bug (fix included)
On WP 6.9+ the Abilities API is present, so the plugin registers its fluid/* abilities even when Elementor is deactivated. Executing one — or the admin group name-collision check — reached GroupsData::get_filter_groups(), which loads FluidUnitModule (it extends Elementor\Core\Base\Module), and PHP fataled with "Class Elementor\Core\Base\Module not found" instead of returning a result. The integration tests caught it. Both filter-group entry points now guard on is_elementor_plugin_active() and degrade to "no filter groups", the same way get_kit_settings already degrades — filter groups carry Kit preset values so they are Elementor-only by nature. The regression is pinned by the WP-tier tests running with Elementor absent.

## The tests
Two suites with separate bootstraps. The WP-only tier deliberately runs without Elementor so GroupsData's no-Elementor degradation stays exercised; the Elementor tier requires the real plugin and creates the default Kit per test (the activation hook never fires under a muplugins_loaded require — same pattern Elementor's own kit tests use). Coverage: Data CRUD (real sanitize_key semantics), GroupsData aggregation/ordering/collision + the degradation path, the Abilities edit_posts/manage_options permission gates and the group/preset execute callbacks, KitRepeaterService get/update/delete/move including the autosave-mirror invariant, ControlRegistry's Kit-backed resolution, and a rendered-Kit-CSS assertion that a seeded preset emits its --arts-fluid-preset-- clamp() variable.

The wp-env image ships PHPUnit 10, but the bundled WordPress test library still needs PHPUnit <= 9.6, so the suites run with the plugin's own dev vendor exposed in-container via a .wp-env.json mapping (which also provides the Yoast polyfills the container lacks). They run in CI in the e2e job, reusing the already-started wp-env.

## Autosave scoping (decision recorded, no code change)
process_autosave() mirrors to the acting user's autosave via get_autosave() with no user id — matching Elementor core's own Kit::add_repeater_row. An admin's write therefore doesn't reach another user's separate open-editor draft. This is an intentional match, documented in a code comment; hardening it to mirror every user's draft would diverge from the framework and mutate other users' in-progress work.

https://claude.ai/code/session_01KGsRfBGPWj5ZJMh9BLLrLa